### PR TITLE
Implement Stratified Splitting on Clusters

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.6"
 manifest_format = "2.0"
-project_hash = "78c4d9386fc17a2d9ca5ea617096d3d7c4ec49e9"
+project_hash = "a5c8b6fcc7abc190c43e23625b0b0ca049467a43"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra", "Requires"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,10 +8,12 @@ ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 ArrayInterface = "7.19.0"
 Clustering = "0.15.8"
 Distances = "0.10"
+Statistics = "1.11.1"
 StatsBase = "0.34.5"

--- a/docs/src/14-cluster-stratified.md
+++ b/docs/src/14-cluster-stratified.md
@@ -1,0 +1,41 @@
+# Cluster Stratified Split
+
+Cluster Stratified Split is a train/test splitting strategy that ensures each cluster (as determined by a clustering algorithm) is split into train and test sets according to a specified allocation method and user-defined train fraction.
+
+## Allocation Methods
+
+- **Equal allocation**: Randomly selects a fixed number `n` of samples from each cluster, then splits those into train/test according to the user-specified `frac` (fraction for train set). The rest of the cluster is unused.
+- **Proportional allocation**: Uses all samples in each cluster, splits them into train/test according to the user-specified `frac` (fraction for train set).
+- **Neyman allocation**: Randomly selects a quota from each cluster (proportional to cluster size and mean standard deviation of features), then splits those into train/test according to the user-specified `frac` (fraction for train set). The rest of the cluster is unused.
+
+## Usage
+
+```julia
+using DataSplits, Clustering
+
+# Assume you have a ClusteringResult `clusters` and a data matrix X
+splitter = ClusterStratifiedSplit(clusters, :equal; n=4, frac=0.7)
+train_idx, test_idx = split(X, splitter)
+
+splitter = ClusterStratifiedSplit(clusters, :proportional; frac=0.7)
+train_idx, test_idx = split(X, splitter)
+
+splitter = ClusterStratifiedSplit(clusters, :neyman; n=4, frac=0.7)
+train_idx, test_idx = split(X, splitter)
+```
+
+## Arguments
+
+- `clusters`: ClusteringResult (from Clustering.jl)
+- `allocation`: `:equal`, `:proportional`, or `:neyman`
+- `n`: Number of samples per cluster (for `:equal` and `:neyman`)
+- `frac`: Fraction of selected samples to use for train (rest go to test)
+
+## Notes
+
+- If `n` is greater than the cluster size, all samples in the cluster are used.
+- For `:proportional`, all samples are always used.
+- For `frac=1.0`, all selected samples go to train; for `frac=0.0`, all go to test.
+- The split is performed **per cluster**; rounding is handled so that the train set always gets the larger share when the split is not exact.
+
+See also: [Clustering.jl](https://github.com/JuliaStats/Clustering.jl)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -17,6 +17,7 @@ A tiny Julia library for rational train/test splitting algorithms:
 | `MinimumDissimilaritySplit`|  Greedy dissimilarity with one candidate | O(N²) time, O(N²) memory |
 | `MaximumDissimilaritySplit`|  Greedy dissimilarity with full pool | O(N²) time, O(N²) memory |
 | `ClusterShuffleSplit`|  Cluster-based shuffle split | O(N²) time, O(N²) memory |
+| `ClusterStratifiedSplit`|  Cluster-based stratified split (equal, proportional, Neyman). Selects a quota per cluster, then splits into train/test according to user fraction. | O(N²) time, O(N²) memory |
 
 All splitting strategies in DataSplits are designed to work with any AbstractArray, including those with non-standard axes. This is achieved by mapping user indices to internal positions, ensuring correctness and extensibility for all data types.
 
@@ -25,4 +26,5 @@ julia> using DataSplits, Distances
 
 julia> train, test = split(X, KennardStoneSplit(0.8))
 julia> train, test = split((X, y), SPXYSplit(0.7; metric = Cityblock()))
+julia> train, test = split(X, ClusterStratifiedSplit(clusters, :equal; n=4, frac=0.7))
 ```

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -8,6 +8,7 @@ include("strategies/KennardStone.jl")
 include("strategies/SPXY.jl")
 include("strategies/OptiSim.jl")
 include("strategies/ClusterShuffleSplit.jl")
+include("strategies/ClusterStratifiedSplit.jl")
 include("clustering/SphereExclusion.jl")
 include("strategies/TargetProperty.jl")
 include("strategies/TimeSplit.jl")
@@ -18,7 +19,7 @@ export LazyCADEXSplit, LazyKennardStoneSplit, KennardStoneSplit
 export SPXYSplit, MDKSSplit
 export OptiSimSplit
 export RandomSplit
-export ClusterShuffleSplit
+export ClusterShuffleSplit, ClusterStratifiedSplit
 export sphere_exclusion
 export TargetPropertySplit
 export TargetPropertyHigh, TargetPropertyLow

--- a/src/strategies/ClusterStratifiedSplit.jl
+++ b/src/strategies/ClusterStratifiedSplit.jl
@@ -1,0 +1,142 @@
+using Random
+using Statistics: std, mean
+import Clustering: ClusteringResult, assignments
+using Clustering
+
+"""
+    ClusterStratifiedSplit(res::ClusteringResult, allocation::Symbol; n=nothing, frac)
+    ClusterStratifiedSplit(f::Function, allocation::Symbol; n=nothing, frac, data)
+
+Cluster-stratified train/test splitter.
+
+Splits each cluster into train/test using one of three allocation methods:
+
+- `:equal`: Randomly selects `n` samples from each cluster, then splits them into train/test according to `frac`.
+- `:proportional`: Uses all samples in each cluster, splits them into train/test according to `frac`.
+- `:neyman`: Randomly selects a Neyman quota from each cluster (based on pooled std), then splits into train/test according to `frac`.
+
+# Arguments
+- `res` or `f(...)`: ClusteringResult or clustering function.
+- `allocation`: `:equal`, `:proportional`, or `:neyman`.
+- `n`: Number of samples per cluster (equal/neyman allocation).
+- `frac`: Fraction of selected samples to use for train (rest go to test).
+
+# Notes
+- If `n` is greater than the cluster size, all samples in the cluster are used.
+- For `:proportional`, all samples are always used.
+- For `frac=1.0`, all selected samples go to train; for `frac=0.0`, all go to test.
+"""
+struct ClusterStratifiedSplit <: SplitStrategy
+  clusters::ClusteringResult
+  allocation::Symbol
+  n::Union{Nothing,Int}
+  frac::Real
+end
+
+ClusterStratifiedSplit(res::ClusteringResult, allocation::Symbol; n = nothing, frac) =
+  ClusterStratifiedSplit(res, allocation, n, frac)
+
+ClusterStratifiedSplit(f::Function, allocation::Symbol; n = nothing, frac, data) =
+  ClusterStratifiedSplit(f(data), allocation; n = n, frac = frac)
+
+"""
+    equal_allocation(cl_ids, idxs_by_cluster, n, rng)
+
+Randomly select `n` samples from each cluster (or all if cluster is smaller).
+Returns a Dict mapping cluster id to selected indices.
+"""
+function equal_allocation(cl_ids, idxs_by_cluster, n, rng)
+  @assert !isnothing(n) "n must be provided for equal allocation"
+  selected = Dict{Int,Vector{Int}}()
+  for cid in cl_ids
+    idxs = idxs_by_cluster[cid]
+    n_select = min(n, length(idxs))
+    idxs_shuffled = copy(idxs)
+    shuffle!(rng, idxs_shuffled)
+    selected[cid] = idxs_shuffled[1:n_select]
+  end
+  return selected
+end
+
+"""
+    proportional_allocation(cl_ids, idxs_by_cluster, rng)
+
+Use all samples in each cluster, shuffled.
+Returns a Dict mapping cluster id to selected indices.
+"""
+function proportional_allocation(cl_ids, idxs_by_cluster, rng)
+  selected = Dict{Int,Vector{Int}}()
+  for cid in cl_ids
+    idxs = idxs_by_cluster[cid]
+    idxs_shuffled = copy(idxs)
+    shuffle!(rng, idxs_shuffled)
+    selected[cid] = idxs_shuffled
+  end
+  return selected
+end
+
+"""
+    neyman_allocation(cl_ids, idxs_by_cluster, n, data, rng)
+
+Randomly select a Neyman quota from each cluster (proportional to cluster size and mean std of features).
+Returns a Dict mapping cluster id to selected indices.
+"""
+function neyman_allocation(cl_ids, idxs_by_cluster, n, data, rng)
+  @assert !isnothing(n) "n must be provided for Neyman allocation"
+  stds = Dict{Int,Float64}()
+  for cid in cl_ids
+    idxs = idxs_by_cluster[cid]
+    cluster_data = data[idxs, :]
+    stds[cid] = mean(std(cluster_data, dims = 1))
+  end
+  numerators = Dict(cid => length(idxs_by_cluster[cid]) * stds[cid] for cid in cl_ids)
+  denom = sum(values(numerators))
+  total = n * length(cl_ids)
+  selected = Dict{Int,Vector{Int}}()
+  for cid in cl_ids
+    prop = numerators[cid] / denom
+    n_select = max(1, round(Int, prop * total))
+    idxs = idxs_by_cluster[cid]
+    idxs_shuffled = copy(idxs)
+    shuffle!(rng, idxs_shuffled)
+    selected[cid] = idxs_shuffled[1:min(n_select, length(idxs))]
+  end
+  return selected
+end
+
+"""
+    cluster_stratified(N, s, rng, data)
+
+Main splitting function. For each cluster, selects indices according to the allocation method,
+then splits those indices into train/test according to `frac`.
+"""
+function cluster_stratified(N, s, rng, data)
+  assigns = assignments(s.clusters)
+  cl_ids = unique(assigns)
+  idxs_by_cluster = Dict(cid => findall(==(cid), assigns) for cid in cl_ids)
+  selected = if s.allocation == :equal
+    equal_allocation(cl_ids, idxs_by_cluster, s.n, rng)
+  elseif s.allocation == :proportional
+    proportional_allocation(cl_ids, idxs_by_cluster, rng)
+  elseif s.allocation == :neyman
+    neyman_allocation(cl_ids, idxs_by_cluster, s.n, data, rng)
+  else
+    error("Unknown allocation method: $(s.allocation)")
+  end
+  train_pos = Int[]
+  test_pos = Int[]
+  for cid in cl_ids
+    idxs = selected[cid]
+    n_train = ceil(Int, s.frac * length(idxs))
+    n_train = min(n_train, length(idxs))
+    train_idxs = idxs[1:n_train]
+    test_idxs = idxs[n_train+1:end]
+    append!(train_pos, train_idxs)
+    append!(test_pos, test_idxs)
+  end
+  return train_pos, test_pos
+end
+
+function _split(data, s::ClusterStratifiedSplit; rng = Random.default_rng())
+  split_with_positions(data, s, cluster_stratified; rng = rng)
+end

--- a/test/test-cluster-stratified-split.jl
+++ b/test/test-cluster-stratified-split.jl
@@ -1,0 +1,40 @@
+using Test
+using DataSplits: split, ClusterStratifiedSplit
+using Clustering
+
+@testset "ClusterStratifiedSplit" begin
+  # Simple synthetic data
+  X = reshape(1:15, 15, 1) # 3 clusters, 5 samples each, 1 feature
+  assigns = vcat(fill(1, 5), fill(2, 5), fill(3, 5))
+  struct DummyClusteringResult <: Clustering.ClusteringResult
+    assignments::Vector{Int}
+  end
+  Clustering.assignments(res::DummyClusteringResult) = res.assignments
+  clusters = DummyClusteringResult(assigns)
+
+  # Equal allocation: 4 per cluster, 50% train
+  s_eq = ClusterStratifiedSplit(clusters, :equal; n = 4, frac = 0.5)
+  train, test = split(X, s_eq)
+  @test length(train) == 6
+  @test length(test) == 6
+  @test all(count(==(cid), assigns[train]) == 2 for cid = 1:3)
+  @test all(count(==(cid), assigns[test]) == 2 for cid = 1:3)
+
+  # Proportional allocation: 50% train
+  s_prop = ClusterStratifiedSplit(clusters, :proportional; frac = 0.5)
+  train, test = split(X, s_prop)
+  @test length(train) == 9
+  @test length(test) == 6
+  @test all(
+    count(==(cid), assigns[train]) + count(==(cid), assigns[test]) == 5 for cid = 1:3
+  )
+
+  # Neyman allocation: 4 per cluster, 50% train
+  s_neyman = ClusterStratifiedSplit(clusters, :neyman; n = 4, frac = 0.5)
+  train, test = split(X, s_neyman)
+  @test length(train) == 6
+  @test length(test) == 6
+  @test all(
+    count(==(cid), assigns[train]) + count(==(cid), assigns[test]) <= 4 for cid = 1:3
+  )
+end


### PR DESCRIPTION
Reference: May RJ, Maier HR, Dandy GC. Data splitting for artificial neural networks using SOM-based stratified sampling. Neural Networks. 2010 Mar;23(2):283–94.

Nice article in which they generalize previous research into a more generic algorithm. Plausibly these algorithms work best when using the original method based on Kohonen Maps and do not necessarily generalize well to other clustering algorithms, but implementing it this way allows more freedom for the user to use it in different processes.