### PR TITLE
feat: add WithValidation combinator for train/val/test splits

### DIFF
--- a/docs/src/15-with-validation.md
+++ b/docs/src/15-with-validation.md
@@ -1,0 +1,109 @@
+```@meta
+CurrentModule = DataSplits
+```
+
+# Validation Cohort (`WithValidation`)
+
+## Overview
+
+`WithValidation` is a combinator that turns any pair of train/test
+strategies into a train/validation/test split. It applies the first
+strategy to separate the test set from the rest of the data, and the
+second strategy to the remaining train pool to carve out a validation
+cohort. The result is a [`TrainValTestSplit`](@ref).
+
+`WithValidation` does not introduce any new selection logic of its own —
+it composes strategies that already exist. Any strategy that returns a
+`TrainTestSplit` (which is every built-in strategy other than the
+combinators themselves) is a valid building block.
+
+## How it works
+
+1. Run `test_strategy` on the full dataset → train_pool / test indices.
+2. Restrict `data` and any auxiliary slot vectors (`target`, `time`,
+   `groups`) to `train_pool`.
+3. Run `val_strategy` on the restricted data → train / val indices in
+   pool-local coordinates.
+4. Map the local indices back to the global index space and return a
+   [`TrainValTestSplit`](@ref).
+
+## Fraction semantics
+
+Each inner strategy interprets its `frac` field relative to its own input,
+consistent with the rest of the package. The total fractions therefore
+combine multiplicatively. For instance:
+
+```julia
+WithValidation(KennardStoneSplit(0.8), KennardStoneSplit(0.8))
+# 80 % train_pool / 20 % test, then 80 % train / 20 % val of the pool
+# Globally: 64 % train, 16 % val, 20 % test
+```
+
+If you need exact global fractions, do the arithmetic on the inner
+fractions yourself. This keeps the contract uniform with single-step
+strategies and avoids hidden behaviour.
+
+## Slot composition
+
+The slot interface ([`consumes`](@ref) / [`fallback_from_data`](@ref)) of
+`WithValidation` is the union of both inner strategies' slots, so any
+combination of `:data`, `:target`, `:time` and `:groups` consumers is
+supported transparently:
+
+```julia
+# Time-aware test split, target-aware validation split
+res = partition(
+    X,
+    WithValidation(TimeSplitOldest(0.8), TargetPropertyHigh(0.8));
+    time = dates,
+    target = y,
+)
+```
+
+The slot keywords are subsetted to `train_pool` before the validation
+strategy is invoked, so each inner strategy sees a vector aligned with
+its input.
+
+## Usage
+
+```julia
+using DataSplits, Distances
+
+# Same strategy for both passes
+res = partition(X, WithValidation(KennardStoneSplit(0.8), KennardStoneSplit(0.8)))
+X_train, X_val, X_test = splitdata(res, X)
+
+# Different strategies, mixed slots
+res = partition(
+    X,
+    WithValidation(GroupShuffleSplit(0.8), RandomSplit(0.8));
+    groups = patient_ids,
+)
+
+# SPXY for both — joint X/y diversity preserved in train and val
+res = partition(
+    X,
+    WithValidation(SPXYSplit(0.8), SPXYSplit(0.8));
+    target = y,
+)
+```
+
+## Notes / Limitations
+
+- Both inner strategies must return a [`TrainTestSplit`](@ref). Passing a
+  combinator that returns a `TrainValTestSplit` or a
+  `CrossValidationSplit` raises `SplitNotImplementedError`.
+- The `rng` keyword is forwarded to both inner strategies. If you need
+  independent randomness, build a custom strategy or call `partition`
+  manually in two stages.
+- Group/time/target consistency is the user's responsibility: the slot
+  vectors must have one entry per observation in `data`, and the
+  validation strategy operates on a contiguous restriction of those
+  vectors.
+
+## API Reference
+
+- [`WithValidation`](@ref)
+- [`TrainValTestSplit`](@ref)
+- [`partition`](@ref)
+- [`splitdata`](@ref)

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -17,6 +17,7 @@ include("strategies/GroupStratifiedSplit.jl")
 include("clustering/SphereExclusion.jl")
 include("strategies/TargetProperty.jl")
 include("strategies/TimeSplit.jl")
+include("strategies/WithValidation.jl")
 
 # Core API
 export partition
@@ -47,6 +48,9 @@ export GroupShuffleSplit, GroupStratifiedSplit
 # Target / time property
 export TargetPropertySplit, TargetPropertyHigh, TargetPropertyLow
 export TimeSplit, TimeSplitOldest, TimeSplitNewest
+
+# Validation cohort combinator
+export WithValidation
 
 # Clustering utility
 export sphere_exclusion

--- a/src/strategies/WithValidation.jl
+++ b/src/strategies/WithValidation.jl
@@ -1,0 +1,108 @@
+using MLUtils: obsview
+
+"""
+    WithValidation(test_strategy, val_strategy) <: AbstractSplitStrategy
+
+Combinator producing a train/validation/test split by composing two existing
+strategies:
+
+1. `test_strategy` is applied to the full dataset, separating the test set
+   from the train pool.
+2. `val_strategy` is applied to the train pool, separating the validation
+   set from the final training set.
+
+Both inner strategies must return a [`TrainTestSplit`](@ref). Each `frac` is
+interpreted relative to its own input, consistent with the rest of the
+package. The total fractions therefore combine multiplicatively — e.g.
+`WithValidation(KennardStoneSplit(0.8), KennardStoneSplit(0.8))` yields
+64 % train, 16 % validation and 20 % test.
+
+The slot interface ([`consumes`](@ref) / [`fallback_from_data`](@ref)) is
+the union of both inner strategies' slots, so any combination of `:data`,
+`:target`, `:time` and `:groups` consumers is supported.
+
+# Fields
+- `test_strategy::AbstractSplitStrategy`: produces the train_pool/test split.
+- `val_strategy::AbstractSplitStrategy`: produces the train/val split inside
+  the train pool.
+
+# Examples
+```julia
+# Same strategy on both passes
+res = partition(X, WithValidation(KennardStoneSplit(0.8), KennardStoneSplit(0.8)))
+X_train, X_val, X_test = splitdata(res, X)
+
+# Mix slots: time-aware test split, target-aware validation split
+res = partition(
+  X,
+  WithValidation(TimeSplitOldest(0.8), TargetPropertyHigh(0.8));
+  time = dates,
+  target = y,
+)
+```
+
+# See also
+[`TrainValTestSplit`](@ref), [`partition`](@ref).
+"""
+struct WithValidation{T<:AbstractSplitStrategy,V<:AbstractSplitStrategy} <:
+       AbstractSplitStrategy
+  test_strategy::T
+  val_strategy::V
+end
+
+_union_slots(a::Tuple, b::Tuple) = (unique((a..., b...))...,)
+
+consumes(w::WithValidation) = _union_slots(consumes(w.test_strategy), consumes(w.val_strategy))
+
+fallback_from_data(w::WithValidation) =
+  _union_slots(fallback_from_data(w.test_strategy), fallback_from_data(w.val_strategy))
+
+function _partition(
+  data,
+  w::WithValidation;
+  target = nothing,
+  time = nothing,
+  groups = nothing,
+  rng = Random.default_rng(),
+  kwargs...,
+)
+  outer = _partition(
+    data,
+    w.test_strategy;
+    target = target,
+    time = time,
+    groups = groups,
+    rng = rng,
+  )
+  outer isa TrainTestSplit || throw(
+    SplitNotImplementedError(
+      "WithValidation requires the test strategy to return a TrainTestSplit, got $(typeof(outer)).",
+    ),
+  )
+
+  train_pool = outer.train
+  test_idx = outer.test
+
+  data_pool = obsview(data, train_pool)
+  target_pool = target === nothing ? nothing : view(target, train_pool)
+  time_pool = time === nothing ? nothing : view(time, train_pool)
+  groups_pool = groups === nothing ? nothing : view(groups, train_pool)
+
+  inner = _partition(
+    data_pool,
+    w.val_strategy;
+    target = target_pool,
+    time = time_pool,
+    groups = groups_pool,
+    rng = rng,
+  )
+  inner isa TrainTestSplit || throw(
+    SplitNotImplementedError(
+      "WithValidation requires the validation strategy to return a TrainTestSplit, got $(typeof(inner)).",
+    ),
+  )
+
+  train_idx = train_pool[inner.train]
+  val_idx = train_pool[inner.test]
+  return TrainValTestSplit(train_idx, val_idx, test_idx)
+end

--- a/test/test-with-validation.jl
+++ b/test/test-with-validation.jl
@@ -1,0 +1,181 @@
+using Test, Random, DataSplits, Distances
+using Dates: Date, Day
+using MLUtils: numobs
+using DataSplits:
+  partition,
+  splitdata,
+  trainindices,
+  testindices,
+  valindices,
+  consumes,
+  fallback_from_data,
+  TrainTestSplit,
+  TrainValTestSplit,
+  CrossValidationSplit,
+  WithValidation,
+  RandomSplit,
+  KennardStoneSplit,
+  SPXYSplit,
+  GroupShuffleSplit,
+  TimeSplitOldest,
+  TargetPropertyHigh,
+  SplitNotImplementedError
+
+N = 60
+
+@testset "Disjoint partition and sizes" begin
+  X = rand(3, N)
+  rng = MersenneTwister(0)
+  res = partition(X, WithValidation(RandomSplit(0.8), RandomSplit(0.75)); rng = rng)
+
+  @test res isa TrainValTestSplit
+  train, val, test = trainindices(res), valindices(res), testindices(res)
+  @test sort(vcat(train, val, test)) == collect(1:N)
+  @test isempty(intersect(train, val))
+  @test isempty(intersect(train, test))
+  @test isempty(intersect(val, test))
+
+  # Outer 0.8 → 48 train_pool / 12 test
+  # Inner 0.75 on the pool → 36 train / 12 val
+  @test length(test) == 12
+  @test length(val) == 12
+  @test length(train) == 36
+end
+
+@testset "splitdata returns three subsets in order" begin
+  X = rand(3, N)
+  res = partition(
+    X,
+    WithValidation(RandomSplit(0.8), RandomSplit(0.75));
+    rng = MersenneTwister(1),
+  )
+  Xtr, Xv, Xte = splitdata(res, X)
+  @test size(Xtr, 2) == length(trainindices(res))
+  @test size(Xv, 2) == length(valindices(res))
+  @test size(Xte, 2) == length(testindices(res))
+end
+
+@testset "Slot union: target consumed by inner strategy" begin
+  X = rand(4, N)
+  y = rand(N)
+  w = WithValidation(RandomSplit(0.8), TargetPropertyHigh(0.75))
+  @test consumes(w) == (:target,)
+
+  res = partition(X, w; target = y, rng = MersenneTwister(2))
+  @test res isa TrainValTestSplit
+  train, val, test = trainindices(res), valindices(res), testindices(res)
+  @test sort(vcat(train, val, test)) == collect(1:N)
+
+  # Within the train pool the validation strategy keeps the highest targets
+  # in `train` and pushes the lowest into `val`.
+  @test minimum(y[train]) >= maximum(y[val])
+end
+
+@testset "Group-aware composition: groups never split across cohorts" begin
+  groups = repeat(1:12; inner = 5)         # 12 groups × 5 obs = 60
+  X = rand(2, N)
+  w = WithValidation(GroupShuffleSplit(0.8), GroupShuffleSplit(0.75))
+  res = partition(X, w; groups = groups, rng = MersenneTwister(3))
+
+  train, val, test = trainindices(res), valindices(res), testindices(res)
+  @test sort(vcat(train, val, test)) == collect(1:N)
+
+  for g in unique(groups)
+    idxs = findall(==(g), groups)
+    locations = (
+      any(i -> i in train, idxs),
+      any(i -> i in val, idxs),
+      any(i -> i in test, idxs),
+    )
+    @test count(identity, locations) == 1
+  end
+end
+
+@testset "Time-aware test split, target-aware validation split" begin
+  X = rand(2, N)
+  dates = [Date(2020, 1, 1) + Day(i - 1) for i = 1:N]
+  y = collect(1.0:N)
+
+  w = WithValidation(TimeSplitOldest(0.8), TargetPropertyHigh(0.75))
+  res = partition(X, w; time = dates, target = y, rng = MersenneTwister(4))
+
+  train, val, test = trainindices(res), valindices(res), testindices(res)
+  @test sort(vcat(train, val, test)) == collect(1:N)
+
+  # All test observations are strictly newer than every train_pool obs
+  pool = vcat(train, val)
+  @test maximum(dates[pool]) <= minimum(dates[test])
+end
+
+@testset "Distance-based outer composition" begin
+  X = rand(5, N)
+  res = partition(
+    X,
+    WithValidation(KennardStoneSplit(0.8), RandomSplit(0.75));
+    rng = MersenneTwister(5),
+  )
+  train, val, test = trainindices(res), valindices(res), testindices(res)
+  @test sort(vcat(train, val, test)) == collect(1:N)
+  @test length(test) == 12
+end
+
+@testset "SPXY (consumes :data and :target) as outer" begin
+  X = rand(4, N)
+  y = rand(N)
+  w = WithValidation(SPXYSplit(0.8), RandomSplit(0.75))
+  @test :target in consumes(w)
+  @test :data in consumes(w)
+
+  res = partition(X, w; target = y, rng = MersenneTwister(6))
+  train, val, test = trainindices(res), valindices(res), testindices(res)
+  @test sort(vcat(train, val, test)) == collect(1:N)
+end
+
+@testset "Reproducibility under fixed rng" begin
+  X = rand(3, N)
+  w = WithValidation(KennardStoneSplit(0.8), RandomSplit(0.75))
+  r1 = partition(X, w; rng = MersenneTwister(7))
+  r2 = partition(X, w; rng = MersenneTwister(7))
+  @test trainindices(r1) == trainindices(r2)
+  @test valindices(r1) == valindices(r2)
+  @test testindices(r1) == testindices(r2)
+end
+
+@testset "Slot trait composition" begin
+  w_data_only = WithValidation(KennardStoneSplit(0.8), KennardStoneSplit(0.8))
+  @test consumes(w_data_only) == (:data,)
+  @test fallback_from_data(w_data_only) == ()
+
+  w_groups = WithValidation(GroupShuffleSplit(0.8), GroupShuffleSplit(0.8))
+  @test consumes(w_groups) == (:groups,)
+  @test :groups in fallback_from_data(w_groups)
+
+  w_mixed = WithValidation(TimeSplitOldest(0.8), TargetPropertyHigh(0.8))
+  @test :time in consumes(w_mixed)
+  @test :target in consumes(w_mixed)
+end
+
+# ---------------------------------------------------------------------------
+# Negative cases
+# ---------------------------------------------------------------------------
+
+# A toy strategy whose result is not a TrainTestSplit; used to exercise the
+# error path in WithValidation.
+struct _NonTrainTestStrategy <: DataSplits.AbstractSplitStrategy end
+DataSplits.consumes(::_NonTrainTestStrategy) = ()
+DataSplits.fallback_from_data(::_NonTrainTestStrategy) = ()
+function DataSplits._partition(data, ::_NonTrainTestStrategy; kwargs...)
+  n = numobs(data)
+  half = div(n, 2)
+  inner = TrainTestSplit(collect(1:half), collect(half+1:n))
+  return CrossValidationSplit([inner])
+end
+
+@testset "Inner result type validation" begin
+  X = rand(2, 20)
+  w_outer_bad = WithValidation(_NonTrainTestStrategy(), RandomSplit(0.75))
+  @test_throws SplitNotImplementedError partition(X, w_outer_bad; rng = MersenneTwister(0))
+
+  w_inner_bad = WithValidation(RandomSplit(0.8), _NonTrainTestStrategy())
+  @test_throws SplitNotImplementedError partition(X, w_inner_bad; rng = MersenneTwister(0))
+end


### PR DESCRIPTION
## Summary

Adds a `WithValidation` combinator that turns any pair of train/test strategies into a single train/validation/test split. Fully additive: no breaking changes, no edits to existing strategies. The result type (`TrainValTestSplit`) and the slot/trait infrastructure introduced in `5e9d19f` are reused as-is — this PR simply provides the first producer of a `TrainValTestSplit`.

## Motivation

After the `partition` refactor, `TrainValTestSplit` exists in `core.jl` but no built-in strategy returns one. Users that need a held-out validation cohort (which is most regression workflows on small / structured data) had no path forward except calling `partition` twice manually and managing index remapping themselves. `WithValidation` removes that friction without committing the package to a particular validation algorithm: any existing strategy that already returns a `TrainTestSplit` becomes a usable building block on either pass.

## Design decisions

These were settled during planning before any code was written. Recapping for review:

### Combinator vs. per-strategy support

Chosen: **combinator**. The alternative — adding a second `frac` (or a `val_frac` keyword) to every strategy — would have required touching all 14 strategies and complicating the `_partition` contract. A combinator keeps the per-strategy code untouched and reuses the existing trait machinery exactly.

### Fraction semantics

Chosen: **each `frac` is interpreted relative to its own input**, exactly as in single-step strategies. The total fractions therefore combine multiplicatively. For example:

```julia
WithValidation(KennardStoneSplit(0.8), KennardStoneSplit(0.8))
# pool  = 80 % of N           (test = 20 %)
# train = 80 % of pool        (val  = 20 % of pool)
# global: 64 % train · 16 % val · 20 % test
```

The user does the arithmetic if they want exact global fractions. Trade-off accepted because it keeps the contract uniform with every other strategy in the package and avoids hidden re-normalisation.

A sugar form `WithValidation(strategy, val_frac::Real)` was considered and **deliberately deferred**. It would require a per-strategy `_rebuild_with_frac` helper, which is invasive. If desirable later, it can be added as a single extra constructor delegating to the current one — no API churn.

### Single `partition` entry point

`WithValidation` produces a `TrainValTestSplit` through the existing `partition` call, consistent with what the refactor set up. No new top-level entry point.

## API surface

```julia
struct WithValidation{T<:AbstractSplitStrategy, V<:AbstractSplitStrategy} <: AbstractSplitStrategy
  test_strategy::T
  val_strategy::V
end
```

Single export: `WithValidation`. Used through the standard pipeline:

```julia
res = partition(X, WithValidation(test_strategy, val_strategy); kwargs...)
X_train, X_val, X_test = splitdata(res, X)
```

## How it works

1. Apply `test_strategy` to the full dataset → `TrainTestSplit(train_pool, test)`.
2. Restrict `data` (via `obsview`) and any auxiliary slot vectors (`target` / `time` / `groups`, via `view`) to `train_pool`.
3. Apply `val_strategy` to the restricted data → `TrainTestSplit(local_train, local_val)` in pool-local coordinates.
4. Map back to global indices and return `TrainValTestSplit(train_pool[local_train], train_pool[local_val], test)`.

If either inner strategy returns anything other than `TrainTestSplit` (e.g. another combinator, a CV split), `SplitNotImplementedError` is raised with a clear message naming the offending type.

## Slot composition

`consumes(WithValidation(a, b)) = consumes(a) ∪ consumes(b)`, deduplicated. Same for `fallback_from_data`. `partition` therefore validates and resolves slots based on the union, and each inner strategy receives only the slots it cares about (the rest are absorbed into `kwargs...` as in every other `_partition`).

This makes mixed-slot composition trivial:

```julia
# Test = future, val = high-target observations within the past
WithValidation(TimeSplitOldest(0.8), TargetPropertyHigh(0.8))
#   consumes -> (:time, :target)
#   fallback_from_data -> (:time, :target)
```

The slot vectors are sliced to the train pool before the second pass, so the inner strategy sees a vector aligned with its input.

## What is NOT in scope

- **Cross-validation.** Will live in a separate effort (likely `feat/cross-validation`) and will provide strategies returning `CrossValidationSplit` (`GroupKFold`, `TimeSeriesCV`, `StratifiedKFold` over target bins, `LeaveOneGroupOut`). Whether to also offer CV variants of the rational selection algorithms (e.g. K folds built via Kennard–Stone) is open and will be discussed there.
- **Independent RNGs per pass.** A single `rng` is forwarded to both inner strategies. If a user needs independent randomness, they call `partition` twice by hand. Adding an `rng_val` keyword is a one-line follow-up if requested.
- **Sugar constructor** `WithValidation(strategy, val_frac::Real)`. Deferred per the design rationale above.

## Open questions

Two points worth confirming before merge:

1. **Naming.** Every other strategy ends in `Split` (`KennardStoneSplit`, `GroupShuffleSplit`, …). I deliberately broke that convention here because `WithValidation` is a combinator, not a selection algorithm; ending it in `Split` would suggest it has its own splitting logic. Happy to rename to `WithValidationSplit` if you prefer to keep the suffix universal.
2. **Sugar `val_frac::Real` constructor.** As noted, this is feasible but requires per-strategy support. Worth doing now or as a follow-up?

## Test plan

`test/test-with-validation.jl` covers:

- Disjoint partition and exact sizes (`length(train) + length(val) + length(test) == N`, pairwise empty intersections).
- `splitdata` returns a 3-tuple aligned with `trainindices`/`valindices`/`testindices`.
- Slot union: outer that does not consume `:target` + inner that does (`TargetPropertyHigh`); strict invariant `min(y[train]) >= max(y[val])` holds within the pool.
- Group-aware composition: when both passes use `GroupShuffleSplit`, no group lands in more than one cohort.
- Mixed-slot composition: `TimeSplitOldest` outer + `TargetPropertyHigh` inner; verifies temporal containment of the test cohort.
- Distance-based outer (`KennardStoneSplit`) + light inner (`RandomSplit`): exercises the matrix-restriction path through `obsview`.
- SPXY (`:data` + `:target`) as outer.
- Reproducibility under fixed `rng`.
- Slot trait composition: `consumes` / `fallback_from_data` of representative pairs.
- Negative cases: an inner strategy returning a non-`TrainTestSplit` raises `SplitNotImplementedError` (both as outer and as inner).

Local run on Julia 1.12.5: **240 / 240 tests pass**, including 46 new assertions in `With Validation` and no regressions in any existing testset.

## Documentation

`docs/src/15-with-validation.md` follows the layout of the per-strategy pages (overview, how it works, fraction semantics, slot composition, usage, notes, API reference). Documenter renders it cleanly: all `@ref` links resolve and the docstring is picked up by the existing `@autodocs` block in `95-reference.md`.

## Compatibility / breaking changes

None. Purely additive:

- One new file `src/strategies/WithValidation.jl`.
- One new include + one new export in `src/DataSplits.jl`.
- One new test file `test/test-with-validation.jl` (auto-discovered by `runtests.jl`).
- One new doc page `docs/src/15-with-validation.md` (auto-included by `make.jl`).

No existing strategy, type or function is modified.

## Pre-existing issues observed (not addressed here)

Spotted while implementing this and worth flagging — but **not part of this PR**:

- `Project.toml` on `api` lists `NPZ = "0.4.3"` in `[compat]` without a corresponding `[deps]` entry, which makes `Pkg.test()` fail at load time. The test dependency itself is declared in `test/Project.toml`. Easy fix: drop the line from the package's `[compat]`. Happy to open a separate one-line PR if you want.
- `docs/src/14-cluster-shuffle.md` and `docs/src/14-cluster-stratified.md` still reference `ClusterShuffleSplit` / `ClusterStratifiedSplit` (renamed to `GroupShuffleSplit` / `GroupStratifiedSplit` in `5e9d19f`), which causes `make.jl` to fail at the cross-reference phase. Not introduced by this PR; I worked around it locally to verify my new page renders cleanly.