### PR TITLE
refactor!: move cohort sizes from strategies to `partition`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,5 @@ repos:
     rev: v2.3.0
     hooks:
       - id: julia-formatter
+        entry: julia --project=@formatter -e 'using JuliaFormatter; format(ARGS)' --
+        files: \.jl$

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.2.0"
 authors = ["Davide Crucitti <davide.crucitti@grheco.com>"]
 
 [deps]
-ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
@@ -14,7 +13,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-ArrayInterface = "6,7"
 Clustering = "0.15"
 Distances = "0.10.3 - 0.11"
 MLUtils = "0.4.8"

--- a/bench/bench_spxy_memory.jl
+++ b/bench/bench_spxy_memory.jl
@@ -11,13 +11,13 @@ D = 100
 X = randn(D, N)
 y = randn(N)
 
-splitter = SPXYSplit(0.7)
+splitter = SPXYSplit()
 
 # Warmup
-DataSplits.split((X, y), splitter)
+partition(X, splitter; target = y, train = 70, test = 30)
 
 # Benchmark
-results = @benchmark DataSplits.split(($X, $y), $splitter)
+results = @benchmark partition($X, $splitter; target = $y, train = 70, test = 30)
 
 mem = minimum(results).memory
 med_time = median(results).time

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -1,6 +1,5 @@
 module DataSplits
 
-include("core.jl")
 include("utils.jl")
 include("validation.jl")
 include("core.jl")

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -2,6 +2,8 @@ module DataSplits
 
 include("core.jl")
 include("utils.jl")
+include("validation.jl")
+include("core.jl")
 include("strategies/random.jl")
 include("strategies/LazyKennardStone.jl")
 include("strategies/KennardStone.jl")

--- a/src/core.jl
+++ b/src/core.jl
@@ -373,9 +373,42 @@ function _check_min_sizes(n_train::Integer, n_val::Integer, n_test::Integer)
 end
 
 
+function Base.show(io::IO, res::TrainTestSplit)
+  print(
+    io,
+    "TrainTestSplit  train: $(length(res.train)) obs  test: $(length(res.test)) obs",
+  )
+end
+
+function Base.show(io::IO, res::TrainValTestSplit)
+  print(
+    io,
+    "TrainValTestSplit  train: $(length(res.train)) obs  val: $(length(res.val)) obs  test: $(length(res.test)) obs",
+  )
+end
+
+function Base.show(io::IO, res::CrossValidationSplit)
+  print(io, "CrossValidationSplit  $(length(res.folds)) folds")
+end
+
+
 # ---------------------------------------------------------------------------
-# Main entry points
+# Result type iteration (enables destructuring: train, test = res)
 # ---------------------------------------------------------------------------
+
+Base.iterate(res::TrainTestSplit, state = 1) =
+  state == 1 ? (res.train, 2) : state == 2 ? (res.test, 3) : nothing
+
+Base.iterate(res::TrainValTestSplit, state = 1) =
+  state == 1 ? (res.train, 2) :
+  state == 2 ? (res.val, 3) : state == 3 ? (res.test, 4) : nothing
+
+Base.iterate(res::CrossValidationSplit, state = 1) =
+  state <= length(res.folds) ? (res.folds[state], state + 1) : nothing
+
+Base.length(res::TrainTestSplit) = 2
+Base.length(res::TrainValTestSplit) = 3
+Base.length(res::CrossValidationSplit) = length(res.folds)
 
 """
     partition(data, alg;

--- a/src/core.jl
+++ b/src/core.jl
@@ -206,8 +206,7 @@ end
 function _resolve_slot(algs::Tuple, data, kwval, slot::Symbol)
   consumers = filter(a -> slot ∈ consumes(a), algs)
   if isempty(consumers)
-    kwval === nothing ||
-      throw(SplitInputError("No strategy uses the `$slot=` keyword."))
+    kwval === nothing || throw(SplitInputError("No strategy uses the `$slot=` keyword."))
     return nothing
   end
   if kwval === nothing
@@ -227,66 +226,142 @@ end
 _slot_for(alg, value, slot::Symbol) = slot ∈ consumes(alg) ? value : nothing
 
 
-# ---------------------------------------------------------------------------
-# Cohort size resolution
-# ---------------------------------------------------------------------------
-
 """
     _resolve_sizes(N, train, validation, test) -> (n_train, n_val, n_test)
 
-Validate and resolve cohort sizes from integer keywords.
+Validate and resolve cohort sizes.
 
-Two interpretations are accepted, distinguished by the sum of the values:
+**Integer form** — two interpretations, distinguished by the sum:
+- sum == `100`: values are percentages of `N`.
+- sum == `N`: values are absolute counts.
+Any other sum is rejected.
 
-- if they sum to **100**, they are treated as **percentages of `N`**;
-- if they sum to **`N`**, they are treated as **absolute counts**.
+**Float form** — values must each be in `(0, 1)` and sum to approximately 1.0.
 
-Any other sum is rejected. When `validation === nothing`, the result has
-`n_val == 0` and only train and test cohorts are produced.
-
-When percentages do not divide `N` evenly, `n_train` and `n_val` are
-rounded to the nearest integer and `n_test` absorbs the remainder so that
-`n_train + n_val + n_test == N`.
+When `validation === nothing`, `n_val == 0` and only train and test cohorts
+are produced. Rounding remainder is absorbed by `n_test`.
 """
-function _resolve_sizes(
-  N::Integer,
-  train::Integer,
-  validation::Union{Integer,Nothing},
-  test::Integer,
-)
-  three_cohort = validation !== nothing
+function _resolve_sizes(N::Integer, train::Integer, ::Nothing, test::Integer)
+  parts = (:train => train, :test => test)
 
-  for (k, v) in (
-    three_cohort ?
-    ((:train, train), (:validation, validation), (:test, test)) :
-    ((:train, train), (:test, test))
-  )
-    v >= 1 ||
-      throw(SplitParameterError("`$k` must be a positive integer, got $v."))
-  end
+  _assert_positive_integer(:N, N)
+  _assert_positive_integer_parts(parts...)
 
-  s = three_cohort ? train + validation + test : train + test
+  n_train, n_test = _resolve_integer_parts(N, parts)
+
+  _check_min_sizes(n_train, n_test)
+
+  return n_train, 0, n_test
+end
+
+function _resolve_sizes(N::Integer, train::Integer, validation::Integer, test::Integer)
+  parts = (:train => train, :validation => validation, :test => test)
+
+  _assert_positive_integer(:N, N)
+  _assert_positive_integer_parts(parts...)
+
+  n_train, n_val, n_test = _resolve_integer_parts(N, parts)
+
+  _check_min_sizes(n_train, n_val, n_test)
+
+  return n_train, n_val, n_test
+end
+
+function _resolve_integer_parts(N::Integer, parts::Tuple)
+  values = last.(parts)
+  s = sum(values)
 
   if s == 100
-    n_train = round(Int, (train * N) / 100)
-    n_val = three_cohort ? round(Int, (validation * N) / 100) : 0
-    n_test = N - n_train - n_val
+    return _resolve_percentage_parts(N, values)
   elseif s == N
-    n_train = train
-    n_val = three_cohort ? validation : 0
-    n_test = test
+    return values
+  end
+
+  throw(
+    SplitParameterError(
+      "Cohort sizes must sum to 100 (percentages) or to N=$N (absolute counts); got $(_format_integer_parts(parts, s)).",
+    ),
+  )
+end
+
+function _resolve_percentage_parts(N::Integer, percentages::Tuple)
+  leading = map(p -> round(Int, (p * N) / 100), Base.front(percentages))
+  final = N - sum(leading)
+
+  return (leading..., final)
+end
+
+function _format_integer_parts(parts::Tuple, total::Integer)
+  expr = join(("$(name)($(value))" for (name, value) in parts), " + ")
+  return "$expr = $total"
+end
+
+function _resolve_sizes(
+  N::Integer,
+  train::Union{Real,ValidFraction},
+  validation::Union{Real,ValidFraction,Nothing},
+  test::Union{Real,ValidFraction,Nothing},
+)
+  _assert_positive_integer(:N, N)
+  train = _as_valid_fraction(train)
+  validation = _as_valid_fraction(validation)
+  test = _as_valid_fraction(test)
+
+  if validation === nothing
+    _assert_unit_fraction_sum(train, test)
   else
-    parts = three_cohort ?
-      "train($train) + validation($validation) + test($test) = $s" :
-      "train($train) + test($test) = $s"
+    _assert_unit_fraction_sum(train, validation, test)
+  end
+
+  return _resolve_sizes(N, train, validation, test)
+end
+
+
+function _resolve_sizes(
+  N::Integer,
+  train::ValidFraction,
+  validation::Nothing,
+  test::Union{ValidFraction,Nothing},
+)
+  n_train = round(Int, train * N)
+  n_val = 0
+  n_test = N - n_train
+
+  _check_min_sizes(n_train, n_test)
+
+  return n_train, n_val, n_test
+end
+
+function _resolve_sizes(
+  N::Integer,
+  train::ValidFraction,
+  validation::ValidFraction,
+  test::ValidFraction,
+)
+  n_train = round(Int, train * N)
+  n_val = round(Int, validation * N)
+  n_test = N - n_train - n_val
+
+  _check_min_sizes(n_train, n_val, n_test)
+
+  return n_train, n_val, n_test
+end
+
+function _check_min_sizes(n_train::Integer, n_test::Integer)
+  if n_train < 1 || n_test < 1
     throw(
       SplitParameterError(
-        "Cohort sizes must sum to 100 (percentages) or to N=$N (absolute counts); got $parts.",
+        "Resolved cohort sizes must each be ≥ 1; got n_train=$n_train, n_test=$n_test.",
       ),
     )
   end
 
-  if n_train < 1 || n_test < 1 || (three_cohort && n_val < 1)
+  return nothing
+end
+
+
+function _check_min_sizes(n_train::Integer, n_val::Integer, n_test::Integer)
+  if n_train < 1 || n_val < 1 || n_test < 1
     throw(
       SplitParameterError(
         "Resolved cohort sizes must each be ≥ 1; got n_train=$n_train, n_val=$n_val, n_test=$n_test.",
@@ -294,75 +369,48 @@ function _resolve_sizes(
     )
   end
 
-  return n_train, n_val, n_test
+  return nothing
 end
 
 
 # ---------------------------------------------------------------------------
-# Main entry point
+# Main entry points
 # ---------------------------------------------------------------------------
 
 """
-    partition(data, alg [, val_alg];
-              train, test, validation=nothing,
+    partition(data, alg;
+              train, test,
               target=nothing, time=nothing, groups=nothing,
-              rng=Random.default_rng()) -> AbstractSplitResult
+              rng=Random.default_rng()) -> TrainTestSplit
 
-Split `data` into train/test (or train/validation/test) according to one or
-two splitting strategies.
+Split `data` into train and test cohorts according to `alg`.
 
-# Arguments
-- `data`: Observation container (matrix, vector, DataFrame, …).
-  Columns are samples for matrices; rows are samples for DataFrames.
-- `alg`: A splitting strategy. With a single strategy `alg`, this strategy
-  separates train from test. With two strategies, `alg` separates the test
-  cohort from the rest.
-- `val_alg` *(optional)*: When given, this second strategy separates the
-  validation cohort from the train pool produced by `alg`.
+# Cohort sizes (`train`, `test`)
 
-# Cohort sizes (`train`, `validation`, `test`)
-
-All sizes are positive integers. Two interpretations are accepted:
-
+Integers are accepted in two ways:
 - **Percentages** — values sum to `100`.
 - **Absolute counts** — values sum to `N = numobs(data)`.
 
-Any other sum is rejected.
+Floats in `(0, 1)` summing to `1.0` are also accepted and converted to counts.
 
 # Auxiliary slots
 
-- `target`: response/property vector used by some strategies (e.g. `SPXYSplit`).
-- `time`: temporal ordering vector used by `TimeSplit` variants.
-- `groups`: group-membership vector used by `GroupShuffleSplit` /
-  `GroupStratifiedSplit`.
-
-When a strategy's required slot is omitted and that slot is in
-`fallback_from_data(alg)`, `data` itself fills the role
-(e.g. `partition(dates, TimeSplitOldest(); train=70, test=30)`).
+- `target`: response/property vector (e.g. for `SPXYSplit`).
+- `time`: temporal ordering vector (e.g. for `TimeSplit`).
+- `groups`: group-membership vector (e.g. for `GroupShuffleSplit`).
 
 # Examples
 ```julia
-# 2 cohorts, percentages
 partition(X, KennardStoneSplit(); train = 80, test = 20)
-
-# 2 cohorts, absolute counts (N = 250)
-partition(X, RandomSplit(); train = 200, test = 50)
-
-# 3 cohorts, mixed strategies
-partition(X, RandomSplit(), KennardStoneSplit();
-          train = 70, validation = 10, test = 20)
-
-# Slot keywords still apply
+partition(X, RandomSplit(); train = 0.8, test = 0.2)
 partition(X, SPXYSplit(); target = y, train = 80, test = 20)
 ```
 """
 function partition(
   data,
-  alg::AbstractSplitStrategy,
-  val_alg::Union{Nothing,AbstractSplitStrategy} = nothing;
-  train::Integer,
-  test::Integer,
-  validation::Union{Integer,Nothing} = nothing,
+  alg::AbstractSplitStrategy;
+  train::Real,
+  test::Real,
   target = nothing,
   time = nothing,
   groups = nothing,
@@ -373,35 +421,80 @@ function partition(
   N = numobs(data)
   N >= 2 || throw(SplitInputError("Cannot split fewer than 2 observations."))
 
-  if val_alg === nothing && validation !== nothing
-    throw(SplitInputError("`validation=` requires a second positional strategy."))
-  end
-  if val_alg !== nothing && validation === nothing
-    throw(SplitInputError("Two strategies require the `validation=` keyword."))
-  end
+  n_train, _, n_test = _resolve_sizes(N, train, nothing, test)
+
+  algs = (alg,)
+  resolved_target = _resolve_slot(algs, data, target, :target)
+  resolved_time = _resolve_slot(algs, data, time, :time)
+  resolved_groups = _resolve_slot(algs, data, groups, :groups)
+
+  data_internal = :data ∈ consumes(alg) ? _to_feature_matrix(data) : data
+
+  return _partition(
+    data_internal,
+    alg;
+    n_train = n_train,
+    n_test = n_test,
+    target = _slot_for(alg, resolved_target, :target),
+    time = _slot_for(alg, resolved_time, :time),
+    groups = _slot_for(alg, resolved_groups, :groups),
+    rng = rng,
+  )
+end
+
+"""
+    partition(data, alg, val_alg;
+              train, validation, test,
+              target=nothing, time=nothing, groups=nothing,
+              rng=Random.default_rng()) -> TrainValTestSplit
+
+Split `data` into train, validation, and test cohorts using two strategies.
+
+`alg` separates the test cohort from the rest; `val_alg` then separates the
+validation cohort from the remaining train pool.
+
+# Cohort sizes (`train`, `validation`, `test`)
+
+Integers are accepted in two ways:
+- **Percentages** — values sum to `100`.
+- **Absolute counts** — values sum to `N = numobs(data)`.
+
+Floats in `(0, 1)` summing to `1.0` are also accepted.
+
+# Examples
+```julia
+partition(X, RandomSplit(), KennardStoneSplit();
+          train = 70, validation = 10, test = 20)
+partition(X, RandomSplit(), KennardStoneSplit();
+          train = 0.7, validation = 0.1, test = 0.2)
+```
+"""
+function partition(
+  data,
+  alg::AbstractSplitStrategy,
+  val_alg::AbstractSplitStrategy;
+  train::Real,
+  validation::Real,
+  test::Real,
+  target = nothing,
+  time = nothing,
+  groups = nothing,
+  rng = Random.default_rng(),
+)
+  isempty(data) &&
+    throw(SplitInputError("Data must not be empty. Please provide a non-empty dataset."))
+  N = numobs(data)
+  N >= 2 || throw(SplitInputError("Cannot split fewer than 2 observations."))
 
   n_train, n_val, n_test = _resolve_sizes(N, train, validation, test)
 
-  algs = val_alg === nothing ? (alg,) : (alg, val_alg)
+  algs = (alg, val_alg)
   resolved_target = _resolve_slot(algs, data, target, :target)
   resolved_time = _resolve_slot(algs, data, time, :time)
   resolved_groups = _resolve_slot(algs, data, groups, :groups)
 
   needs_matrix = any(a -> :data ∈ consumes(a), algs)
   data_internal = needs_matrix ? _to_feature_matrix(data) : data
-
-  if val_alg === nothing
-    return _partition(
-      data_internal,
-      alg;
-      n_train = n_train,
-      n_test = n_test,
-      target = _slot_for(alg, resolved_target, :target),
-      time = _slot_for(alg, resolved_time, :time),
-      groups = _slot_for(alg, resolved_groups, :groups),
-      rng = rng,
-    )
-  end
 
   outer = _partition(
     data_internal,
@@ -423,11 +516,9 @@ function partition(
   test_idx = outer.test
 
   data_inner = obsview(data_internal, train_pool)
-  inner_target =
-    resolved_target === nothing ? nothing : view(resolved_target, train_pool)
+  inner_target = resolved_target === nothing ? nothing : view(resolved_target, train_pool)
   inner_time = resolved_time === nothing ? nothing : view(resolved_time, train_pool)
-  inner_groups =
-    resolved_groups === nothing ? nothing : view(resolved_groups, train_pool)
+  inner_groups = resolved_groups === nothing ? nothing : view(resolved_groups, train_pool)
 
   inner = _partition(
     data_inner,

--- a/src/core.jl
+++ b/src/core.jl
@@ -14,9 +14,12 @@ using Tables
 Abstract supertype for all splitting strategies.
 
 To implement a custom strategy, subtype this and define:
-- `_partition(data, alg; target, time, groups, rng)` returning an `AbstractSplitResult`
-- `consumes(::MyStrategy)` returning a tuple of symbols from `(:data, :target, :time, :groups)`
-- `fallback_from_data(::MyStrategy)` returning the subset of `consumes` that can fall back to `data`
+- `_partition(data, alg; n_train, n_test, target, time, groups, rng)`
+  returning an `AbstractSplitResult`.
+- `consumes(::MyStrategy)` returning a tuple of symbols from
+  `(:data, :target, :time, :groups)`.
+- `fallback_from_data(::MyStrategy)` returning the subset of `consumes`
+  that can fall back to `data`.
 """
 abstract type AbstractSplitStrategy end
 
@@ -43,7 +46,7 @@ A result type representing a train/test split.
 
 # Examples
 ```julia
-res = partition(X, KennardStoneSplit(0.8))
+res = partition(X, KennardStoneSplit(); train = 80, test = 20)
 X_train, X_test = splitdata(res, X)
 ```
 """
@@ -64,7 +67,8 @@ A result type representing a train/validation/test split.
 
 # Examples
 ```julia
-res = partition(X, SomeTrainValTestStrategy(...))
+res = partition(X, RandomSplit(), KennardStoneSplit();
+                train = 70, validation = 10, test = 20)
 X_train, X_val, X_test = splitdata(res, X)
 ```
 """
@@ -81,14 +85,6 @@ A result type representing a k-fold cross-validation split.
 
 # Fields
 - `folds::Vector{<:AbstractSplitResult}`: One result per fold.
-
-# Examples
-```julia
-res = partition(X, SomeCVStrategy(...))
-for (X_train, X_test) in splitdata(res, X)
-    # ...
-end
-```
 """
 struct CrossValidationSplit{T<:AbstractSplitResult} <: AbstractSplitResult
   folds::Vector{T}
@@ -142,12 +138,6 @@ train/test (and optionally validation) indices in `res`.
 
 When `data` is a DataFrame or other Tables.jl-compatible container,
 `splitdata` returns subsets of the same type.
-
-# Examples
-```julia
-res = partition(X, KennardStoneSplit(0.8))
-X_train, X_test = splitdata(res, X)
-```
 """
 function splitdata(res::AbstractSplitResult, data)
   throw(
@@ -169,12 +159,6 @@ splitdata(res::CrossValidationSplit, data) = [splitdata(fold, data) for fold in 
 
 Like `splitdata` but returns lazy views via `MLUtils.obsview` — no data is
 copied. Prefer `splitdata` when you need independent copies.
-
-# Examples
-```julia
-res = partition(X, RandomSplit(0.8))
-X_train, X_test = splitview(res, X)
-```
 """
 splitview(res::TrainTestSplit, data) = (obsview(data, res.train), obsview(data, res.test))
 
@@ -193,12 +177,6 @@ splitview(res::CrossValidationSplit, data) = [splitview(fold, data) for fold in 
 
 Return the named slots this strategy reads, as a tuple of symbols from
 `(:data, :target, :time, :groups)`.
-
-- `:data` — the strategy inspects observation values (e.g. for distances).
-  Omitting it means only `numobs` is needed (e.g. `RandomSplit`).
-- `:target` — the strategy reads a response/property vector.
-- `:time` — the strategy reads a temporal ordering vector.
-- `:groups` — the strategy reads a group-membership vector.
 """
 consumes(::AbstractSplitStrategy) = ()
 
@@ -223,26 +201,101 @@ end
 
 
 # ---------------------------------------------------------------------------
-# Auxiliary slot resolution
+# Slot resolution (works for one or two strategies via a tuple of algs)
 # ---------------------------------------------------------------------------
 
-function _resolve_slot(alg, data, kwval, slot::Symbol)
-  if slot ∈ consumes(alg)
-    if kwval === nothing
-      if slot ∈ fallback_from_data(alg)
-        kwval = data
-      else
-        throw(SplitInputError("$(typeof(alg)) requires the `$slot=` keyword."))
-      end
-    end
-    kwval isa AbstractVector ||
-      throw(SplitInputError("`$slot` must be a 1D AbstractVector, got $(typeof(kwval))."))
-    return kwval
-  else
+function _resolve_slot(algs::Tuple, data, kwval, slot::Symbol)
+  consumers = filter(a -> slot ∈ consumes(a), algs)
+  if isempty(consumers)
     kwval === nothing ||
-      throw(SplitInputError("$(typeof(alg)) does not use the `$slot=` keyword."))
+      throw(SplitInputError("No strategy uses the `$slot=` keyword."))
     return nothing
   end
+  if kwval === nothing
+    if all(a -> slot ∈ fallback_from_data(a), consumers)
+      kwval = data
+    else
+      bad = first(filter(a -> slot ∉ fallback_from_data(a), consumers))
+      throw(SplitInputError("$(typeof(bad)) requires the `$slot=` keyword."))
+    end
+  end
+  kwval isa AbstractVector ||
+    throw(SplitInputError("`$slot` must be a 1D AbstractVector, got $(typeof(kwval))."))
+  return kwval
+end
+
+# For the per-strategy call: only forward the slot if this strategy consumes it.
+_slot_for(alg, value, slot::Symbol) = slot ∈ consumes(alg) ? value : nothing
+
+
+# ---------------------------------------------------------------------------
+# Cohort size resolution
+# ---------------------------------------------------------------------------
+
+"""
+    _resolve_sizes(N, train, validation, test) -> (n_train, n_val, n_test)
+
+Validate and resolve cohort sizes from integer keywords.
+
+Two interpretations are accepted, distinguished by the sum of the values:
+
+- if they sum to **100**, they are treated as **percentages of `N`**;
+- if they sum to **`N`**, they are treated as **absolute counts**.
+
+Any other sum is rejected. When `validation === nothing`, the result has
+`n_val == 0` and only train and test cohorts are produced.
+
+When percentages do not divide `N` evenly, `n_train` and `n_val` are
+rounded to the nearest integer and `n_test` absorbs the remainder so that
+`n_train + n_val + n_test == N`.
+"""
+function _resolve_sizes(
+  N::Integer,
+  train::Integer,
+  validation::Union{Integer,Nothing},
+  test::Integer,
+)
+  three_cohort = validation !== nothing
+
+  for (k, v) in (
+    three_cohort ?
+    ((:train, train), (:validation, validation), (:test, test)) :
+    ((:train, train), (:test, test))
+  )
+    v >= 1 ||
+      throw(SplitParameterError("`$k` must be a positive integer, got $v."))
+  end
+
+  s = three_cohort ? train + validation + test : train + test
+
+  if s == 100
+    n_train = round(Int, (train * N) / 100)
+    n_val = three_cohort ? round(Int, (validation * N) / 100) : 0
+    n_test = N - n_train - n_val
+  elseif s == N
+    n_train = train
+    n_val = three_cohort ? validation : 0
+    n_test = test
+  else
+    parts = three_cohort ?
+      "train($train) + validation($validation) + test($test) = $s" :
+      "train($train) + test($test) = $s"
+    throw(
+      SplitParameterError(
+        "Cohort sizes must sum to 100 (percentages) or to N=$N (absolute counts); got $parts.",
+      ),
+    )
+  end
+
+  if n_train < 1 || n_test < 1 || (three_cohort && n_val < 1)
+    throw(
+      SplitParameterError(
+        "Resolved cohort sizes must each be ≥ 1; got n_train=$n_train, n_val=$n_val, n_test=$n_test.",
+      ),
+    )
+  end
+
+  return n_train, n_val, n_test
 end
 
 
@@ -251,46 +304,66 @@ end
 # ---------------------------------------------------------------------------
 
 """
-    partition(data, alg::AbstractSplitStrategy;
+    partition(data, alg [, val_alg];
+              train, test, validation=nothing,
               target=nothing, time=nothing, groups=nothing,
               rng=Random.default_rng()) -> AbstractSplitResult
 
-Split `data` into train/test (or train/val/test, or cross-validation folds)
-according to `alg`.
+Split `data` into train/test (or train/validation/test) according to one or
+two splitting strategies.
 
 # Arguments
 - `data`: Observation container (matrix, vector, DataFrame, …).
   Columns are samples for matrices; rows are samples for DataFrames.
-- `alg`: A splitting strategy.
+- `alg`: A splitting strategy. With a single strategy `alg`, this strategy
+  separates train from test. With two strategies, `alg` separates the test
+  cohort from the rest.
+- `val_alg` *(optional)*: When given, this second strategy separates the
+  validation cohort from the train pool produced by `alg`.
 
-# Keywords
-- `target`: Response / property vector used by some strategies (e.g. `SPXYSplit`).
-- `time`: Temporal ordering vector used by `TimeSplit` variants.
-- `groups`: Group-membership vector used by `GroupShuffleSplit` / `GroupStratifiedSplit`.
-- `rng`: Random number generator.
+# Cohort sizes (`train`, `validation`, `test`)
 
-# Fallback rule
-When a strategy's required keyword is omitted and `fallback_from_data(alg)`
-includes that slot, `data` itself is used for that role. This makes
-single-input calls natural:
+All sizes are positive integers. Two interpretations are accepted:
 
-```julia
-partition(dates, TimeSplitOldest(0.8))          # dates is both data and time
-partition(y, TargetPropertyHigh(0.8))           # y is both data and target
-partition(ids, GroupShuffleSplit(0.8))          # ids is both data and groups
-```
+- **Percentages** — values sum to `100`.
+- **Absolute counts** — values sum to `N = numobs(data)`.
+
+Any other sum is rejected.
+
+# Auxiliary slots
+
+- `target`: response/property vector used by some strategies (e.g. `SPXYSplit`).
+- `time`: temporal ordering vector used by `TimeSplit` variants.
+- `groups`: group-membership vector used by `GroupShuffleSplit` /
+  `GroupStratifiedSplit`.
+
+When a strategy's required slot is omitted and that slot is in
+`fallback_from_data(alg)`, `data` itself fills the role
+(e.g. `partition(dates, TimeSplitOldest(); train=70, test=30)`).
 
 # Examples
 ```julia
-res = partition(X, KennardStoneSplit(0.8))
-res = partition(X, SPXYSplit(0.7); target=y)
-res = partition(X, GroupShuffleSplit(0.8); groups=patient_ids)
-df_train, df_test = splitdata(res, df)
+# 2 cohorts, percentages
+partition(X, KennardStoneSplit(); train = 80, test = 20)
+
+# 2 cohorts, absolute counts (N = 250)
+partition(X, RandomSplit(); train = 200, test = 50)
+
+# 3 cohorts, mixed strategies
+partition(X, RandomSplit(), KennardStoneSplit();
+          train = 70, validation = 10, test = 20)
+
+# Slot keywords still apply
+partition(X, SPXYSplit(); target = y, train = 80, test = 20)
 ```
 """
 function partition(
   data,
-  alg::AbstractSplitStrategy;
+  alg::AbstractSplitStrategy,
+  val_alg::Union{Nothing,AbstractSplitStrategy} = nothing;
+  train::Integer,
+  test::Integer,
+  validation::Union{Integer,Nothing} = nothing,
   target = nothing,
   time = nothing,
   groups = nothing,
@@ -298,42 +371,80 @@ function partition(
 )
   isempty(data) &&
     throw(SplitInputError("Data must not be empty. Please provide a non-empty dataset."))
-  numobs(data) < 2 && throw(SplitInputError("Cannot split fewer than 2 observations."))
+  N = numobs(data)
+  N >= 2 || throw(SplitInputError("Cannot split fewer than 2 observations."))
 
-  resolved_target = _resolve_slot(alg, data, target, :target)
-  resolved_time = _resolve_slot(alg, data, time, :time)
-  resolved_groups = _resolve_slot(alg, data, groups, :groups)
+  if val_alg === nothing && validation !== nothing
+    throw(SplitInputError("`validation=` requires a second positional strategy."))
+  end
+  if val_alg !== nothing && validation === nothing
+    throw(SplitInputError("Two strategies require the `validation=` keyword."))
+  end
 
-  data_internal = :data ∈ consumes(alg) ? _to_feature_matrix(data) : data
+  n_train, n_val, n_test = _resolve_sizes(N, train, validation, test)
 
-  return _partition(
+  algs = val_alg === nothing ? (alg,) : (alg, val_alg)
+  resolved_target = _resolve_slot(algs, data, target, :target)
+  resolved_time = _resolve_slot(algs, data, time, :time)
+  resolved_groups = _resolve_slot(algs, data, groups, :groups)
+
+  needs_matrix = any(a -> :data ∈ consumes(a), algs)
+  data_internal = needs_matrix ? _to_feature_matrix(data) : data
+
+  if val_alg === nothing
+    return _partition(
+      data_internal,
+      alg;
+      n_train = n_train,
+      n_test = n_test,
+      target = _slot_for(alg, resolved_target, :target),
+      time = _slot_for(alg, resolved_time, :time),
+      groups = _slot_for(alg, resolved_groups, :groups),
+      rng = rng,
+    )
+  end
+
+  outer = _partition(
     data_internal,
     alg;
-    target = resolved_target,
-    time = resolved_time,
-    groups = resolved_groups,
+    n_train = n_train + n_val,
+    n_test = n_test,
+    target = _slot_for(alg, resolved_target, :target),
+    time = _slot_for(alg, resolved_time, :time),
+    groups = _slot_for(alg, resolved_groups, :groups),
     rng = rng,
   )
+  outer isa TrainTestSplit || throw(
+    SplitNotImplementedError(
+      "First strategy must return a TrainTestSplit, got $(typeof(outer)).",
+    ),
+  )
+
+  train_pool = outer.train
+  test_idx = outer.test
+
+  data_inner = obsview(data_internal, train_pool)
+  inner_target =
+    resolved_target === nothing ? nothing : view(resolved_target, train_pool)
+  inner_time = resolved_time === nothing ? nothing : view(resolved_time, train_pool)
+  inner_groups =
+    resolved_groups === nothing ? nothing : view(resolved_groups, train_pool)
+
+  inner = _partition(
+    data_inner,
+    val_alg;
+    n_train = n_train,
+    n_test = n_val,
+    target = _slot_for(val_alg, inner_target, :target),
+    time = _slot_for(val_alg, inner_time, :time),
+    groups = _slot_for(val_alg, inner_groups, :groups),
+    rng = rng,
+  )
+  inner isa TrainTestSplit || throw(
+    SplitNotImplementedError(
+      "Validation strategy must return a TrainTestSplit, got $(typeof(inner)).",
+    ),
+  )
+
+  return TrainValTestSplit(train_pool[inner.train], train_pool[inner.test], test_idx)
 end
-
-
-# ---------------------------------------------------------------------------
-# ValidFraction
-# ---------------------------------------------------------------------------
-
-struct ValidFraction{T<:Real}
-  frac::T
-  function ValidFraction(frac::T) where {T<:Real}
-    if !(0 < frac < 1)
-      throw(SplitParameterError("Fraction must be strictly between 0 and 1. Got $frac."))
-    end
-    new{T}(frac)
-  end
-end
-
-Base.:*(vf::ValidFraction, x::Number) = vf.frac * x
-Base.:*(x::Number, vf::ValidFraction) = x * vf.frac
-Base.:+(x::Number, vf::ValidFraction) = x + vf.frac
-Base.:-(x::Number, vf::ValidFraction) = x - vf.frac
-Base.float(vf::ValidFraction) = vf.frac
-Base.convert(::Type{T}, vf::ValidFraction) where {T<:Number} = convert(T, vf.frac)

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,5 +1,4 @@
 using Random
-using ArrayInterface
 using MLUtils: numobs, getobs, obsview
 using Tables
 

--- a/src/strategies/GroupShuffleSplit.jl
+++ b/src/strategies/GroupShuffleSplit.jl
@@ -1,60 +1,55 @@
 using Random
 
 """
-    GroupShuffleSplit(frac::Real) <: AbstractSplitStrategy
+    GroupShuffleSplit() <: AbstractSplitStrategy
 
 Group-aware train/test splitting. Accumulates whole groups into the training
-set (in random order) until the requested fraction is reached.
+set (in random order) until the requested training size is reached.
 
 Groups are passed as a vector of membership IDs via the `groups=` keyword.
 Any grouping is valid: cluster assignments, patient IDs, scaffold labels,
 batch numbers, site identifiers, graph communities, etc.
 
-# Fields
-- `frac::ValidFraction`: Fraction of samples in the training set (0 < frac < 1)
-
 # Notes
-Because groups are added whole, the actual training fraction may overshoot
-the requested value. No attempt is made to minimise this overshoot.
+Because groups are added whole, the actual train cohort size may overshoot
+the requested `n_train`. No attempt is made to minimise this overshoot.
 
 # Examples
 ```julia
 # ids is both data and groups
-res = partition(ids, GroupShuffleSplit(0.8))
+res = partition(ids, GroupShuffleSplit(); train=80, test=20)
 
 # X is split; group membership provided separately
-res = partition(X, GroupShuffleSplit(0.8); groups=patient_ids)
+res = partition(X, GroupShuffleSplit(); groups=patient_ids, train=80, test=20)
 X_train, X_test = splitdata(res, X)
 
 # With Clustering.jl
 using Clustering
-res = partition(X, GroupShuffleSplit(0.8); groups=assignments(kmeans(X, 5)))
+res = partition(X, GroupShuffleSplit();
+                groups=assignments(kmeans(X, 5)), train=80, test=20)
 ```
 """
-struct GroupShuffleSplit <: AbstractSplitStrategy
-  frac::ValidFraction
-end
-
-GroupShuffleSplit(frac::Real) = GroupShuffleSplit(ValidFraction(frac))
+struct GroupShuffleSplit <: AbstractSplitStrategy end
 
 consumes(::GroupShuffleSplit) = (:groups,)
 fallback_from_data(::GroupShuffleSplit) = (:groups,)
 
 function _partition(
   data,
-  s::GroupShuffleSplit;
+  ::GroupShuffleSplit;
   groups,
+  n_train,
+  n_test,
   rng = Random.default_rng(),
   kwargs...,
 )
-  N = numobs(data)
   cl_ids = unique(groups)
   shuffle!(rng, cl_ids)
   train_pos = Int[]
   test_pos = Int[]
   for cid in cl_ids
     idxs = findall(==(cid), groups)
-    if length(train_pos) / N < float(s.frac)
+    if length(train_pos) < n_train
       append!(train_pos, idxs)
     else
       append!(test_pos, idxs)

--- a/src/strategies/GroupStratifiedSplit.jl
+++ b/src/strategies/GroupStratifiedSplit.jl
@@ -2,7 +2,7 @@ using Random
 using Statistics: std, mean
 
 """
-    GroupStratifiedSplit(allocation::Symbol; n=nothing, frac) <: AbstractSplitStrategy
+    GroupStratifiedSplit(allocation::Symbol; n=nothing) <: AbstractSplitStrategy
 
 Group-stratified train/test splitting with flexible allocation methods.
 
@@ -13,22 +13,25 @@ batch numbers, site identifiers, graph communities, etc.
 # Fields
 - `allocation::Symbol`: Allocation method — `:equal`, `:proportional`, or `:neyman`.
 - `n::Union{Nothing,Int}`: Samples per group for `:equal` and `:neyman`.
-- `frac::Real`: Fraction of selected samples assigned to training (rest go to test).
 
 # Allocation methods
 - `:proportional` — use all samples from each group (shuffled).
 - `:equal` — select `n` samples from each group (requires `n`).
 - `:neyman` — select proportional to group size × within-group std (requires `n`).
 
+The training fraction within each group is derived from the global cohort
+sizes (`n_train / N`).
+
 # Examples
 ```julia
-res = partition(X, GroupStratifiedSplit(:proportional; frac=0.8); groups=patient_ids)
+res = partition(X, GroupStratifiedSplit(:proportional);
+                groups=patient_ids, train=80, test=20)
 X_train, X_test = splitdata(res, X)
 
 # With Clustering.jl
 using Clustering
-res = partition(X, GroupStratifiedSplit(:equal; n=5, frac=0.8);
-                groups=assignments(kmeans(X, 4)))
+res = partition(X, GroupStratifiedSplit(:equal; n=5);
+                groups=assignments(kmeans(X, 4)), train=80, test=20)
 ```
 
 # References
@@ -38,11 +41,10 @@ Using SOM-Based Stratified Sampling. *Neural Networks* 2010, 23(2), 283–294.
 struct GroupStratifiedSplit <: AbstractSplitStrategy
   allocation::Symbol
   n::Union{Nothing,Int}
-  frac::Real
 end
 
-GroupStratifiedSplit(allocation::Symbol; n = nothing, frac) =
-  GroupStratifiedSplit(allocation, n, frac)
+GroupStratifiedSplit(allocation::Symbol; n = nothing) =
+  GroupStratifiedSplit(allocation, n)
 
 consumes(::GroupStratifiedSplit) = (:groups,)
 fallback_from_data(::GroupStratifiedSplit) = (:groups,)
@@ -91,9 +93,13 @@ function _partition(
   data,
   s::GroupStratifiedSplit;
   groups,
+  n_train,
+  n_test,
   rng = Random.default_rng(),
   kwargs...,
 )
+  N = numobs(data)
+  frac = n_train / N
   cl_ids = unique(groups)
   idxs_by_cluster = Dict(cid => findall(==(cid), groups) for cid in cl_ids)
   selected = if s.allocation == :equal
@@ -113,9 +119,9 @@ function _partition(
   test_pos = Int[]
   for cid in cl_ids
     idxs = selected[cid]
-    n_train = min(ceil(Int, s.frac * length(idxs)), length(idxs))
-    append!(train_pos, idxs[1:n_train])
-    append!(test_pos, idxs[n_train+1:end])
+    n_train_cid = min(ceil(Int, frac * length(idxs)), length(idxs))
+    append!(train_pos, idxs[1:n_train_cid])
+    append!(test_pos, idxs[n_train_cid+1:end])
   end
   return TrainTestSplit(train_pos, test_pos)
 end

--- a/src/strategies/GroupStratifiedSplit.jl
+++ b/src/strategies/GroupStratifiedSplit.jl
@@ -43,8 +43,7 @@ struct GroupStratifiedSplit <: AbstractSplitStrategy
   n::Union{Nothing,Int}
 end
 
-GroupStratifiedSplit(allocation::Symbol; n = nothing) =
-  GroupStratifiedSplit(allocation, n)
+GroupStratifiedSplit(allocation::Symbol; n = nothing) = GroupStratifiedSplit(allocation, n)
 
 consumes(::GroupStratifiedSplit) = (:groups,)
 fallback_from_data(::GroupStratifiedSplit) = (:groups,)
@@ -121,7 +120,7 @@ function _partition(
     idxs = selected[cid]
     n_train_cid = min(ceil(Int, frac * length(idxs)), length(idxs))
     append!(train_pos, idxs[1:n_train_cid])
-    append!(test_pos, idxs[n_train_cid+1:end])
+    append!(test_pos, idxs[(n_train_cid+1):end])
   end
   return TrainTestSplit(train_pos, test_pos)
 end

--- a/src/strategies/KennardStone.jl
+++ b/src/strategies/KennardStone.jl
@@ -1,7 +1,7 @@
 using Distances, MLUtils
 
 """
-    KennardStoneSplit{T} <: AbstractSplitStrategy
+    KennardStoneSplit <: AbstractSplitStrategy
 
 In-memory Kennard-Stone (CADEX) algorithm for train/test splitting.
 
@@ -9,33 +9,35 @@ Precomputes the full N×N distance matrix; prefer `LazyKennardStoneSplit`
 for large datasets where that is prohibitive.
 
 # Fields
-- `frac::ValidFraction{T}`: Fraction of data to use for training (0 < frac < 1)
 - `metric::Distances.SemiMetric`: Distance metric (default: `Euclidean()`)
 
 # Examples
 ```julia
-res = partition(X, KennardStoneSplit(0.8))
+res = partition(X, KennardStoneSplit(); train = 80, test = 20)
 X_train, X_test = splitdata(res, X)
 
-res = partition(X, KennardStoneSplit(0.7, Cityblock()))
+res = partition(X, KennardStoneSplit(Cityblock()); train = 70, test = 30)
 ```
 """
-struct KennardStoneSplit{T} <: AbstractSplitStrategy
-  frac::ValidFraction{T}
+struct KennardStoneSplit <: AbstractSplitStrategy
   metric::Distances.SemiMetric
 end
 
-KennardStoneSplit(frac::Real) = KennardStoneSplit(ValidFraction(frac), Euclidean())
-KennardStoneSplit(frac::Real, metric) = KennardStoneSplit(ValidFraction(frac), metric)
+KennardStoneSplit() = KennardStoneSplit(Euclidean())
 
 const CADEXSplit = KennardStoneSplit
 
 consumes(::KennardStoneSplit) = (:data,)
 fallback_from_data(::KennardStoneSplit) = ()
 
-function _partition(data, s::KennardStoneSplit; rng = Random.GLOBAL_RNG, kwargs...)
-  N = numobs(data)
-  n_train, _ = train_test_counts(N, s.frac)
+function _partition(
+  data,
+  s::KennardStoneSplit;
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   D = distance_matrix(data, s.metric)
   train_pos, test_pos = kennard_stone_from_distance_matrix(D, n_train)
   return TrainTestSplit(train_pos, test_pos)
@@ -44,10 +46,12 @@ end
 function _partition(
   data::AbstractVector{<:AbstractVector},
   s::KennardStoneSplit;
+  n_train,
+  n_test,
   rng = Random.GLOBAL_RNG,
   kwargs...,
 )
-  _partition(stack(data), s; rng)
+  _partition(stack(data), s; n_train, n_test, rng)
 end
 
 """

--- a/src/strategies/KennardStone.jl
+++ b/src/strategies/KennardStone.jl
@@ -63,8 +63,8 @@ function find_most_distant_pair(D::AbstractMatrix)
   n = size(D, 1)
   max_d = -Inf
   i₁, i₂ = 1, 2
-  @inbounds for i = 1:n-1
-    for j = i+1:n
+  @inbounds for i = 1:(n-1)
+    for j = (i+1):n
       if D[i, j] > max_d
         max_d = D[i, j]
         i₁, i₂ = i, j
@@ -93,6 +93,6 @@ function kennard_stone_from_distance_matrix(D::AbstractMatrix, n_train::Integer)
     min_dists[k_idx] = -Inf
   end
   train_idx = selected_order[1:n_train]
-  test_idx = selected_order[n_train+1:end]
+  test_idx = selected_order[(n_train+1):end]
   return train_idx, test_idx
 end

--- a/src/strategies/LazyKennardStone.jl
+++ b/src/strategies/LazyKennardStone.jl
@@ -7,32 +7,34 @@ Memory-efficient Kennard-Stone (CADEX) algorithm. Computes distances
 on-the-fly (O(N) storage) rather than precomputing the full N×N matrix.
 
 # Fields
-- `frac::ValidFraction`: Fraction of data to use for training (0 < frac < 1)
 - `metric::Distances.SemiMetric`: Distance metric (default: `Euclidean()`)
 
 # Examples
 ```julia
-res = partition(X, LazyKennardStoneSplit(0.8))
+res = partition(X, LazyKennardStoneSplit(); train = 80, test = 20)
 X_train, X_test = splitdata(res, X)
 ```
 """
 struct LazyKennardStoneSplit <: AbstractSplitStrategy
-  frac::ValidFraction
   metric::Distances.SemiMetric
 end
 
-LazyKennardStoneSplit(frac::Real) = LazyKennardStoneSplit(ValidFraction(frac), Euclidean())
-LazyKennardStoneSplit(frac::Real, metric) =
-  LazyKennardStoneSplit(ValidFraction(frac), metric)
+LazyKennardStoneSplit() = LazyKennardStoneSplit(Euclidean())
 
 const LazyCADEXSplit = LazyKennardStoneSplit
 
 consumes(::LazyKennardStoneSplit) = (:data,)
 fallback_from_data(::LazyKennardStoneSplit) = ()
 
-function _partition(data, s::LazyKennardStoneSplit; rng = Random.GLOBAL_RNG, kwargs...)
+function _partition(
+  data,
+  s::LazyKennardStoneSplit;
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   N = numobs(data)
-  n_train, _ = train_test_counts(N, s.frac)
   i₁, i₂ = find_most_distant_pair(data, s.metric)
   selected = falses(N)
   selected[i₁] = selected[i₂] = true

--- a/src/strategies/LazyOptiSim.jl
+++ b/src/strategies/LazyOptiSim.jl
@@ -8,7 +8,6 @@ Memory-efficient, lazy implementation of the OptiSim (Clark 1997) dissimilarity
 selection strategy. Computes distances on-the-fly; avoids the full N×N matrix.
 
 # Fields
-- `frac::ValidFraction`: Fraction of samples in the training subset (0 < frac < 1)
 - `max_subsample_size::Int`: Size of the temporary candidate subsample (default: 10)
 - `distance_cutoff::Float64`: Similarity threshold (default: 0.35)
 - `metric::Distances.SemiMetric`: Distance metric (default: `Euclidean()`)
@@ -18,36 +17,31 @@ selection strategy. Computes distances on-the-fly; avoids the full N×N matrix.
   Diverse Representative Subsets. *J. Chem. Inf. Comput. Sci.*, 37(6), 1181–1188.
 """
 struct LazyOptiSimSplit <: AbstractSplitStrategy
-  frac::ValidFraction
   max_subsample_size::Int
   distance_cutoff::Float64
   metric::Distances.SemiMetric
 end
 
-function LazyOptiSimSplit(
-  frac::Real;
+function LazyOptiSimSplit(;
   max_subsample_size = 10,
   distance_cutoff = 0.35,
   metric = Euclidean(),
 )
-  LazyOptiSimSplit(ValidFraction(frac), max_subsample_size, distance_cutoff, metric)
-end
-
-function LazyOptiSimSplit(
-  frac::ValidFraction;
-  max_subsample_size = 10,
-  distance_cutoff = 0.35,
-  metric = Euclidean(),
-)
-  LazyOptiSimSplit(frac, max_subsample_size, distance_cutoff, metric)
+  LazyOptiSimSplit(max_subsample_size, distance_cutoff, metric)
 end
 
 consumes(::LazyOptiSimSplit) = (:data,)
 fallback_from_data(::LazyOptiSimSplit) = ()
 
-function _partition(X, s::LazyOptiSimSplit; rng = Random.GLOBAL_RNG, kwargs...)
+function _partition(
+  X,
+  s::LazyOptiSimSplit;
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   N = numobs(X)
-  n_train, _ = train_test_counts(N, s.frac)
   candidates = Set(1:N)
   selected = Set{Int}()
   push!(selected, rand(rng, candidates))

--- a/src/strategies/LazySPXY.jl
+++ b/src/strategies/LazySPXY.jl
@@ -9,24 +9,22 @@ Memory-efficient SPXY splitting strategy. Computes distances on-the-fly
 (O(N) storage) rather than precomputing the full N×N matrix.
 
 # Fields
-- `frac::ValidFraction`: Fraction of data to use for training (0 < frac < 1)
 - `metric_X::Distances.SemiMetric`: Distance metric for `X` (default: `Euclidean()`)
 - `metric_y::Distances.SemiMetric`: Distance metric for `y` (default: `Euclidean()`)
 
 # Examples
 ```julia
-res = partition(X, LazySPXYSplit(0.8); target=y)
+res = partition(X, LazySPXYSplit(); target=y, train=80, test=20)
 X_train, X_test = splitdata(res, X)
 ```
 """
 struct LazySPXYSplit <: AbstractSplitStrategy
-  frac::ValidFraction
   metric_X::Distances.SemiMetric
   metric_y::Distances.SemiMetric
 end
 
-LazySPXYSplit(frac::Real; metric_X = Euclidean(), metric_y = Euclidean()) =
-  LazySPXYSplit(ValidFraction(frac), metric_X, metric_y)
+LazySPXYSplit(; metric_X = Euclidean(), metric_y = Euclidean()) =
+  LazySPXYSplit(metric_X, metric_y)
 
 consumes(::LazySPXYSplit) = (:data, :target)
 fallback_from_data(::LazySPXYSplit) = ()
@@ -39,26 +37,22 @@ Uses Mahalanobis distance for `X` and Euclidean for `y`, normalised and summed
 as in SPXY. Computes distances on-the-fly (O(N) storage).
 
 # Fields
-- `frac::ValidFraction`: Fraction of data to use for training (0 < frac < 1)
 - `metric_X::Union{Nothing,Distances.SemiMetric}`: Distance metric for `X`;
   if `nothing`, Mahalanobis is computed from the data at split time.
 - `metric_y::Distances.SemiMetric`: Distance metric for `y` (default: `Euclidean()`)
 
 # Examples
 ```julia
-res = partition(X, LazyMDKSSplit(0.7); target=y)
+res = partition(X, LazyMDKSSplit(); target=y, train=70, test=30)
 X_train, X_test = splitdata(res, X)
 ```
 """
 struct LazyMDKSSplit <: AbstractSplitStrategy
-  frac::ValidFraction
   metric_X::Union{Nothing,Distances.SemiMetric}
   metric_y::Distances.SemiMetric
 end
 
-function LazyMDKSSplit(frac::Real; metric = nothing)
-  LazyMDKSSplit(ValidFraction(frac), metric, Euclidean())
-end
+LazyMDKSSplit(; metric = nothing) = LazyMDKSSplit(metric, Euclidean())
 
 consumes(::LazyMDKSSplit) = (:data, :target)
 fallback_from_data(::LazyMDKSSplit) = ()
@@ -113,21 +107,49 @@ end
 # _partition implementations
 # ---------------------------------------------------------------------------
 
-function _partition(X, s::LazySPXYSplit; target, rng = Random.GLOBAL_RNG, kwargs...)
+function _partition(
+  X,
+  s::LazySPXYSplit;
+  target,
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   max_X, max_y = _find_max_distance_XY(X, target, s.metric_X, s.metric_y)
   max_X = max_X == 0.0 ? 1.0 : max_X
   max_y = max_y == 0.0 ? 1.0 : max_y
   metric = LazySPXYMetric(s.metric_X, s.metric_y, max_X, max_y)
   data = XYObsTable(X, target)
-  return _partition(data, LazyKennardStoneSplit(s.frac, metric); rng)
+  return _partition(
+    data,
+    LazyKennardStoneSplit(metric);
+    n_train = n_train,
+    n_test = n_test,
+    rng = rng,
+  )
 end
 
-function _partition(X, s::LazyMDKSSplit; target, rng = Random.GLOBAL_RNG, kwargs...)
+function _partition(
+  X,
+  s::LazyMDKSSplit;
+  target,
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   metric_X = s.metric_X === nothing ? Mahalanobis(cov(X; dims = 2)) : s.metric_X
   max_X, max_y = _find_max_distance_XY(X, target, metric_X, s.metric_y)
   max_X = max_X == 0.0 ? 1.0 : max_X
   max_y = max_y == 0.0 ? 1.0 : max_y
   metric = LazySPXYMetric(metric_X, s.metric_y, max_X, max_y)
   data = XYObsTable(X, target)
-  return _partition(data, LazyKennardStoneSplit(s.frac, metric); rng)
+  return _partition(
+    data,
+    LazyKennardStoneSplit(metric);
+    n_train = n_train,
+    n_test = n_test,
+    rng = rng,
+  )
 end

--- a/src/strategies/MaximumDissimilarity.jl
+++ b/src/strategies/MaximumDissimilarity.jl
@@ -1,5 +1,5 @@
 """
-    MaximumDissimilaritySplit(frac; distance_cutoff=0.35, metric=Euclidean())
+    MaximumDissimilaritySplit(; distance_cutoff=0.35, metric=Euclidean())
 
 Full OptiSim strategy (Clark 1997). Alias for `OptiSimSplit` with
 `max_subsample_size = N` — considers all remaining candidates each iteration.
@@ -13,34 +13,41 @@ Full OptiSim strategy (Clark 1997). Alias for `OptiSimSplit` with
 
 # Examples
 ```julia
-res = partition(X, MaximumDissimilaritySplit(0.7))
+res = partition(X, MaximumDissimilaritySplit(); train=70, test=30)
 X_train, X_test = splitdata(res, X)
 ```
 """
 struct MaximumDissimilaritySplit <: AbstractSplitStrategy
-  frac::ValidFraction
   distance_cutoff::Float64
   metric::PreMetric
 end
 
-function MaximumDissimilaritySplit(frac::Real; distance_cutoff = 0.35, metric = Euclidean())
-  MaximumDissimilaritySplit(ValidFraction(frac), distance_cutoff, metric)
+function MaximumDissimilaritySplit(; distance_cutoff = 0.35, metric = Euclidean())
+  MaximumDissimilaritySplit(distance_cutoff, metric)
 end
 
 consumes(::MaximumDissimilaritySplit) = (:data,)
 fallback_from_data(::MaximumDissimilaritySplit) = ()
 
-function _partition(X, s::MaximumDissimilaritySplit; rng = Random.GLOBAL_RNG, kwargs...)
+function _partition(
+  X,
+  s::MaximumDissimilaritySplit;
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   N = numobs(X)
   _partition(
     X,
-    OptiSimSplit(
-      s.frac;
+    OptiSimSplit(;
       max_subsample_size = N,
       distance_cutoff = s.distance_cutoff,
       metric = s.metric,
     );
-    rng,
+    n_train = n_train,
+    n_test = n_test,
+    rng = rng,
   )
 end
 
@@ -51,37 +58,40 @@ Lazy (on-the-fly distances) variant of `MaximumDissimilaritySplit`.
 
 # Examples
 ```julia
-res = partition(X, LazyMaximumDissimilaritySplit(0.7))
+res = partition(X, LazyMaximumDissimilaritySplit(); train=70, test=30)
 X_train, X_test = splitdata(res, X)
 ```
 """
 struct LazyMaximumDissimilaritySplit <: AbstractSplitStrategy
-  frac::ValidFraction
   distance_cutoff::Float64
   metric::Distances.SemiMetric
 end
 
-function LazyMaximumDissimilaritySplit(
-  frac::Real;
-  distance_cutoff = 0.35,
-  metric = Euclidean(),
-)
-  LazyMaximumDissimilaritySplit(ValidFraction(frac), distance_cutoff, metric)
+function LazyMaximumDissimilaritySplit(; distance_cutoff = 0.35, metric = Euclidean())
+  LazyMaximumDissimilaritySplit(distance_cutoff, metric)
 end
 
 consumes(::LazyMaximumDissimilaritySplit) = (:data,)
 fallback_from_data(::LazyMaximumDissimilaritySplit) = ()
 
-function _partition(X, s::LazyMaximumDissimilaritySplit; rng = Random.GLOBAL_RNG, kwargs...)
+function _partition(
+  X,
+  s::LazyMaximumDissimilaritySplit;
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   N = numobs(X)
   _partition(
     X,
-    LazyOptiSimSplit(
-      s.frac;
+    LazyOptiSimSplit(;
       max_subsample_size = N,
       distance_cutoff = s.distance_cutoff,
       metric = s.metric,
     );
+    n_train = n_train,
+    n_test = n_test,
     rng = rng,
   )
 end

--- a/src/strategies/MinimumDissimilarity.jl
+++ b/src/strategies/MinimumDissimilarity.jl
@@ -15,11 +15,7 @@ X_train, X_test = splitdata(res, X)
 ```
 """
 function MinimumDissimilaritySplit(; distance_cutoff = 0.35, metric = Euclidean())
-  OptiSimSplit(;
-    max_subsample_size = 1,
-    distance_cutoff = distance_cutoff,
-    metric = metric,
-  )
+  OptiSimSplit(; max_subsample_size = 1, distance_cutoff = distance_cutoff, metric = metric)
 end
 
 """

--- a/src/strategies/MinimumDissimilarity.jl
+++ b/src/strategies/MinimumDissimilarity.jl
@@ -1,5 +1,5 @@
 """
-    MinimumDissimilaritySplit(frac; distance_cutoff=0.35, metric=Euclidean())
+    MinimumDissimilaritySplit(; distance_cutoff=0.35, metric=Euclidean())
 
 Greedy dissimilarity selection (Clark 1997). Alias for `OptiSimSplit` with
 `max_subsample_size = 1` (considers only one candidate per iteration).
@@ -10,13 +10,12 @@ Greedy dissimilarity selection (Clark 1997). Alias for `OptiSimSplit` with
 
 # Examples
 ```julia
-res = partition(X, MinimumDissimilaritySplit(0.7))
+res = partition(X, MinimumDissimilaritySplit(); train=70, test=30)
 X_train, X_test = splitdata(res, X)
 ```
 """
-function MinimumDissimilaritySplit(frac::Real; distance_cutoff = 0.35, metric = Euclidean())
-  OptiSimSplit(
-    frac;
+function MinimumDissimilaritySplit(; distance_cutoff = 0.35, metric = Euclidean())
+  OptiSimSplit(;
     max_subsample_size = 1,
     distance_cutoff = distance_cutoff,
     metric = metric,
@@ -30,36 +29,39 @@ Lazy (on-the-fly distances) variant of `MinimumDissimilaritySplit`.
 
 # Examples
 ```julia
-res = partition(X, LazyMinimumDissimilaritySplit(0.7))
+res = partition(X, LazyMinimumDissimilaritySplit(); train=70, test=30)
 X_train, X_test = splitdata(res, X)
 ```
 """
 struct LazyMinimumDissimilaritySplit <: AbstractSplitStrategy
-  frac::ValidFraction
   distance_cutoff::Float64
   metric::Distances.SemiMetric
 end
 
-function LazyMinimumDissimilaritySplit(
-  frac::Real;
-  distance_cutoff = 0.35,
-  metric = Euclidean(),
-)
-  LazyMinimumDissimilaritySplit(ValidFraction(frac), distance_cutoff, metric)
+function LazyMinimumDissimilaritySplit(; distance_cutoff = 0.35, metric = Euclidean())
+  LazyMinimumDissimilaritySplit(distance_cutoff, metric)
 end
 
 consumes(::LazyMinimumDissimilaritySplit) = (:data,)
 fallback_from_data(::LazyMinimumDissimilaritySplit) = ()
 
-function _partition(X, s::LazyMinimumDissimilaritySplit; rng = Random.GLOBAL_RNG, kwargs...)
+function _partition(
+  X,
+  s::LazyMinimumDissimilaritySplit;
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   _partition(
     X,
-    LazyOptiSimSplit(
-      s.frac;
+    LazyOptiSimSplit(;
       max_subsample_size = 1,
       distance_cutoff = s.distance_cutoff,
       metric = s.metric,
     );
+    n_train = n_train,
+    n_test = n_test,
     rng = rng,
   )
 end

--- a/src/strategies/MoraisLimaMartinSplit.jl
+++ b/src/strategies/MoraisLimaMartinSplit.jl
@@ -1,31 +1,46 @@
 using Random, Distances
 
 """
-    MoraisLimaMartinSplit(frac; swap_frac=0.1, metric=Euclidean())
+    MoraisLimaMartinSplit(; swap_frac=0.1, metric=Euclidean())
 
 Kennard–Stone initialisation followed by random swapping of a fraction of
 samples between train and test sets.
 
 # Fields
-- `frac::ValidFraction{T}`: Fraction of data to use for training (0 < frac < 1)
-- `swap_frac::ValidFraction{T}`: Fraction of samples to swap (0 < swap_frac < 1)
+- `swap_frac::Float64`: Fraction of samples to swap (0 < swap_frac < 1)
 - `metric::Distances.SemiMetric`: Distance metric for Kennard–Stone (default: `Euclidean()`)
+
+# Examples
+```julia
+res = partition(X, MoraisLimaMartinSplit(); train=80, test=20)
+res = partition(X, MoraisLimaMartinSplit(; swap_frac=0.05); train=80, test=20)
+```
 """
-struct MoraisLimaMartinSplit{T,M<:Distances.SemiMetric} <: AbstractSplitStrategy
-  frac::ValidFraction{T}
-  swap_frac::ValidFraction{T}
+struct MoraisLimaMartinSplit{M<:Distances.SemiMetric} <: AbstractSplitStrategy
+  swap_frac::Float64
   metric::M
 end
 
-MoraisLimaMartinSplit(frac::Real; swap_frac::Real = 0.1, metric = Euclidean()) =
-  MoraisLimaMartinSplit(ValidFraction(frac), ValidFraction(swap_frac), metric)
+function MoraisLimaMartinSplit(; swap_frac::Real = 0.1, metric = Euclidean())
+  0 < swap_frac < 1 || throw(
+    SplitParameterError("`swap_frac` must be strictly between 0 and 1, got $swap_frac."),
+  )
+  MoraisLimaMartinSplit(Float64(swap_frac), metric)
+end
 
 consumes(::MoraisLimaMartinSplit) = (:data,)
 fallback_from_data(::MoraisLimaMartinSplit) = ()
 
-function _partition(data, s::MoraisLimaMartinSplit; rng = Random.GLOBAL_RNG, kwargs...)
-  ks = KennardStoneSplit(s.frac, s.metric)
-  tt = _partition(data, ks; rng = rng)
+function _partition(
+  data,
+  s::MoraisLimaMartinSplit;
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
+  ks = KennardStoneSplit(s.metric)
+  tt = _partition(data, ks; n_train = n_train, n_test = n_test, rng = rng)
   train_idx = copy(tt.train)
   test_idx = copy(tt.test)
   n_swap = round(Int, s.swap_frac * min(length(train_idx), length(test_idx)))

--- a/src/strategies/MoraisLimaMartinSplit.jl
+++ b/src/strategies/MoraisLimaMartinSplit.jl
@@ -7,7 +7,7 @@ Kennard–Stone initialisation followed by random swapping of a fraction of
 samples between train and test sets.
 
 # Fields
-- `swap_frac::Float64`: Fraction of samples to swap (0 < swap_frac < 1)
+- `swap_frac::ValidFraction`: Fraction of samples to swap (0 < swap_frac < 1)
 - `metric::Distances.SemiMetric`: Distance metric for Kennard–Stone (default: `Euclidean()`)
 
 # Examples
@@ -16,16 +16,13 @@ res = partition(X, MoraisLimaMartinSplit(); train=80, test=20)
 res = partition(X, MoraisLimaMartinSplit(; swap_frac=0.05); train=80, test=20)
 ```
 """
-struct MoraisLimaMartinSplit{M<:Distances.SemiMetric} <: AbstractSplitStrategy
-  swap_frac::Float64
+struct MoraisLimaMartinSplit{T<:Real,M<:Distances.SemiMetric} <: AbstractSplitStrategy
+  swap_frac::ValidFraction{T}
   metric::M
 end
 
 function MoraisLimaMartinSplit(; swap_frac::Real = 0.1, metric = Euclidean())
-  0 < swap_frac < 1 || throw(
-    SplitParameterError("`swap_frac` must be strictly between 0 and 1, got $swap_frac."),
-  )
-  MoraisLimaMartinSplit(Float64(swap_frac), metric)
+  MoraisLimaMartinSplit(ValidFraction(swap_frac), metric)
 end
 
 consumes(::MoraisLimaMartinSplit) = (:data,)

--- a/src/strategies/OptiSim.jl
+++ b/src/strategies/OptiSim.jl
@@ -1,12 +1,11 @@
 using Distances, Random
 
 """
-    OptiSimSplit(frac; max_subsample_size=10, distance_cutoff=0.35, metric=Euclidean())
+    OptiSimSplit(; max_subsample_size=10, distance_cutoff=0.35, metric=Euclidean())
 
 OptiSim (Clark 1997) K-dissimilarity selection strategy for train/test splitting.
 
 # Fields
-- `frac::ValidFraction`: Fraction of samples in the training subset (0 < frac < 1)
 - `max_subsample_size::Integer`: Size of the temporary candidate subsample
 - `distance_cutoff::Real`: Two points are "similar" if their distance < `distance_cutoff`
 - `metric::Distances.SemiMetric`: Distance metric (default: `Euclidean()`)
@@ -17,41 +16,36 @@ OptiSim (Clark 1997) K-dissimilarity selection strategy for train/test splitting
 
 # Examples
 ```julia
-res = partition(X, OptiSimSplit(0.7; max_subsample_size=10))
+res = partition(X, OptiSimSplit(; max_subsample_size=10); train=70, test=30)
 X_train, X_test = splitdata(res, X)
 ```
 """
 struct OptiSimSplit <: AbstractSplitStrategy
-  frac::ValidFraction
   max_subsample_size::Integer
   distance_cutoff::Real
   metric::Distances.SemiMetric
 end
 
-function OptiSimSplit(
-  frac::Real;
+function OptiSimSplit(;
   max_subsample_size = 10,
   distance_cutoff = 0.35,
   metric = Euclidean(),
 )
-  OptiSimSplit(ValidFraction(frac), max_subsample_size, distance_cutoff, metric)
-end
-
-function OptiSimSplit(
-  frac::ValidFraction;
-  max_subsample_size = 10,
-  distance_cutoff = 0.35,
-  metric = Euclidean(),
-)
-  OptiSimSplit(frac, max_subsample_size, distance_cutoff, metric)
+  OptiSimSplit(max_subsample_size, distance_cutoff, metric)
 end
 
 consumes(::OptiSimSplit) = (:data,)
 fallback_from_data(::OptiSimSplit) = ()
 
-function _partition(X, s::OptiSimSplit; rng = Random.GLOBAL_RNG, kwargs...)
+function _partition(
+  X,
+  s::OptiSimSplit;
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   N = numobs(X)
-  n_train, _ = train_test_counts(N, s.frac)
   D = distance_matrix(X, s.metric)
   selected_positions =
     optisim(D, n_train, s.max_subsample_size, s.distance_cutoff; rng = rng)

--- a/src/strategies/OptiSim.jl
+++ b/src/strategies/OptiSim.jl
@@ -37,14 +37,7 @@ end
 consumes(::OptiSimSplit) = (:data,)
 fallback_from_data(::OptiSimSplit) = ()
 
-function _partition(
-  X,
-  s::OptiSimSplit;
-  n_train,
-  n_test,
-  rng = Random.GLOBAL_RNG,
-  kwargs...,
-)
+function _partition(X, s::OptiSimSplit; n_train, n_test, rng = Random.GLOBAL_RNG, kwargs...)
   N = numobs(X)
   D = distance_matrix(X, s.metric)
   selected_positions =

--- a/src/strategies/SPXY.jl
+++ b/src/strategies/SPXY.jl
@@ -29,8 +29,7 @@ struct SPXYSplit <: AbstractSplitStrategy
   metric_y::Distances.SemiMetric
 end
 
-SPXYSplit(; metric_X = Euclidean(), metric_y = Euclidean()) =
-  SPXYSplit(metric_X, metric_y)
+SPXYSplit(; metric_X = Euclidean(), metric_y = Euclidean()) = SPXYSplit(metric_X, metric_y)
 
 consumes(::SPXYSplit) = (:data, :target)
 fallback_from_data(::SPXYSplit) = ()

--- a/src/strategies/SPXY.jl
+++ b/src/strategies/SPXY.jl
@@ -2,7 +2,7 @@ using Statistics: cov
 using Distances
 
 """
-    SPXYSplit(frac; metric_X=Euclidean(), metric_y=Euclidean())
+    SPXYSplit(; metric_X=Euclidean(), metric_y=Euclidean())
 
 Sample set Partitioning based on joint X–Y distance (SPXY).
 
@@ -10,14 +10,14 @@ A variant of Kennard–Stone where the joint distance matrix is the element-wise
 sum of the (normalised) pairwise distance matrices of `X` and `y`.
 
 # Fields
-- `frac::ValidFraction`: Fraction of samples in the training subset (0 < frac < 1)
 - `metric_X::Distances.SemiMetric`: Distance metric for `X` (default: `Euclidean()`)
 - `metric_y::Distances.SemiMetric`: Distance metric for `y` (default: `Euclidean()`)
 
 # Examples
 ```julia
-res = partition(X, SPXYSplit(0.7); target=y)
-res = partition(X, SPXYSplit(0.7; metric_X=Mahalanobis(cov(X; dims=2))); target=y)
+res = partition(X, SPXYSplit(); target=y, train=70, test=30)
+res = partition(X, SPXYSplit(; metric_X=Mahalanobis(cov(X; dims=2)));
+                target=y, train=70, test=30)
 X_train, X_test = splitdata(res, X)
 ```
 
@@ -25,19 +25,18 @@ X_train, X_test = splitdata(res, X)
 [`KennardStoneSplit`](@ref) — the classical variant that uses only `X`.
 """
 struct SPXYSplit <: AbstractSplitStrategy
-  frac::ValidFraction
   metric_X::Distances.SemiMetric
   metric_y::Distances.SemiMetric
 end
 
-SPXYSplit(frac::Real; metric_X = Euclidean(), metric_y = Euclidean()) =
-  SPXYSplit(ValidFraction(frac), metric_X, metric_y)
+SPXYSplit(; metric_X = Euclidean(), metric_y = Euclidean()) =
+  SPXYSplit(metric_X, metric_y)
 
 consumes(::SPXYSplit) = (:data, :target)
 fallback_from_data(::SPXYSplit) = ()
 
 """
-    MDKSSplit(frac; metric=nothing)
+    MDKSSplit(; metric=nothing)
 
 Minimum Dissimilarity Kennard–Stone (MDKS) split using Mahalanobis distance for `X`
 and Euclidean distance for `y`.
@@ -47,8 +46,9 @@ matrix of `X` at split time.
 
 # Examples
 ```julia
-res = partition(X, MDKSSplit(0.7); target=y)
-res = partition(X, MDKSSplit(0.7; metric=Mahalanobis(cov(X; dims=2))); target=y)
+res = partition(X, MDKSSplit(); target=y, train=70, test=30)
+res = partition(X, MDKSSplit(; metric=Mahalanobis(cov(X; dims=2)));
+                target=y, train=70, test=30)
 X_train, X_test = splitdata(res, X)
 ```
 
@@ -56,11 +56,10 @@ X_train, X_test = splitdata(res, X)
 [`SPXYSplit`](@ref)
 """
 struct MDKSSplit <: AbstractSplitStrategy
-  frac::ValidFraction
   metric::Union{Nothing,PreMetric}
 end
 
-MDKSSplit(frac::Real; metric = nothing) = MDKSSplit(ValidFraction(frac), metric)
+MDKSSplit(; metric = nothing) = MDKSSplit(metric)
 
 consumes(::MDKSSplit) = (:data, :target)
 fallback_from_data(::MDKSSplit) = ()
@@ -70,9 +69,15 @@ fallback_from_data(::MDKSSplit) = ()
   return D ./ maximum(D)
 end
 
-function _partition(X, s::SPXYSplit; target, rng = Random.GLOBAL_RNG, kwargs...)
-  N = numobs(X)
-  n_train, _ = train_test_counts(N, s.frac)
+function _partition(
+  X,
+  s::SPXYSplit;
+  target,
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   DX = _norm_pairwise(X, s.metric_X)
   DY = _norm_pairwise(target, s.metric_y)
   DX .+= DY
@@ -80,7 +85,22 @@ function _partition(X, s::SPXYSplit; target, rng = Random.GLOBAL_RNG, kwargs...)
   return TrainTestSplit(train_idx, test_idx)
 end
 
-function _partition(X, s::MDKSSplit; target, rng = Random.GLOBAL_RNG, kwargs...)
+function _partition(
+  X,
+  s::MDKSSplit;
+  target,
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   metric_X = s.metric === nothing ? Mahalanobis(cov(X; dims = 2)) : s.metric
-  _partition(X, SPXYSplit(s.frac, metric_X, Euclidean()); target = target, rng = rng)
+  _partition(
+    X,
+    SPXYSplit(metric_X, Euclidean());
+    target = target,
+    n_train = n_train,
+    n_test = n_test,
+    rng = rng,
+  )
 end

--- a/src/strategies/TargetProperty.jl
+++ b/src/strategies/TargetProperty.jl
@@ -1,47 +1,42 @@
 """
-    TargetPropertySplit{T} <: AbstractSplitStrategy
+    TargetPropertySplit(order::Symbol) <: AbstractSplitStrategy
 
 Splits observations by sorting a 1D property vector and selecting the top or
-bottom fraction as the training set.
+bottom slice as the training set.
 
 # Fields
-- `frac::ValidFraction{T}`: Fraction of data to use for training (0 < frac < 1)
 - `order::Symbol`: `:high` selects the largest values for training; `:low` selects the smallest.
 
 # Examples
 ```julia
 # y is both data and the property to sort by
-res = partition(y, TargetPropertyHigh(0.8))
+res = partition(y, TargetPropertyHigh(); train=80, test=20)
 y_train, y_test = splitdata(res, y)
 
 # X is the data to split; y is the property
-res = partition(X, TargetPropertyHigh(0.8); target=y)
+res = partition(X, TargetPropertyHigh(); target=y, train=80, test=20)
 X_train, X_test = splitdata(res, X)
 ```
 """
-struct TargetPropertySplit{T} <: AbstractSplitStrategy
-  frac::ValidFraction{T}
+struct TargetPropertySplit <: AbstractSplitStrategy
   order::Symbol
 end
 
-TargetPropertySplit(frac::Real, order::Symbol) =
-  TargetPropertySplit(ValidFraction(frac), order)
-
 """
-    TargetPropertyHigh(frac)
+    TargetPropertyHigh()
 
-Alias for `TargetPropertySplit(frac, :high)` — selects the highest-valued
+Alias for `TargetPropertySplit(:high)` — selects the highest-valued
 observations for the training set.
 """
-TargetPropertyHigh(frac::Real) = TargetPropertySplit(frac, :high)
+TargetPropertyHigh() = TargetPropertySplit(:high)
 
 """
-    TargetPropertyLow(frac)
+    TargetPropertyLow()
 
-Alias for `TargetPropertySplit(frac, :low)` — selects the lowest-valued
+Alias for `TargetPropertySplit(:low)` — selects the lowest-valued
 observations for the training set.
 """
-TargetPropertyLow(frac::Real) = TargetPropertySplit(frac, :low)
+TargetPropertyLow() = TargetPropertySplit(:low)
 
 consumes(::TargetPropertySplit) = (:target,)
 fallback_from_data(::TargetPropertySplit) = (:target,)
@@ -50,12 +45,12 @@ function _partition(
   data,
   s::TargetPropertySplit;
   target,
+  n_train,
+  n_test,
   rng = Random.GLOBAL_RNG,
   kwargs...,
 )
-  N = numobs(data)
   descending = s.order in (:desc, :high, :largest, :max, :maximum)
   idx = sortperm(target; rev = descending)
-  n_train, _ = train_test_counts(N, s.frac)
   return TrainTestSplit(idx[1:n_train], idx[n_train+1:end])
 end

--- a/src/strategies/TargetProperty.jl
+++ b/src/strategies/TargetProperty.jl
@@ -52,5 +52,5 @@ function _partition(
 )
   descending = s.order in (:desc, :high, :largest, :max, :maximum)
   idx = sortperm(target; rev = descending)
-  return TrainTestSplit(idx[1:n_train], idx[n_train+1:end])
+  return TrainTestSplit(idx[1:n_train], idx[(n_train+1):end])
 end

--- a/src/strategies/TimeSplit.jl
+++ b/src/strategies/TimeSplit.jl
@@ -1,54 +1,59 @@
 """
-    TimeSplit{T} <: AbstractSplitStrategy
+    TimeSplit(order::Symbol=:asc) <: AbstractSplitStrategy
 
 Splits a 1D array of dates/times into train/test sets, grouping by unique
 values so that no group is split across train and test.
 
-The actual training fraction may be slightly above the requested one
-but never below.
+The actual training cohort size may slightly overshoot `n_train` but never
+fall below it.
 
 # Fields
-- `frac::ValidFraction{T}`: Fraction of data to use for training (0 < frac < 1)
 - `order::Symbol`: `:asc` puts the oldest observations in train (default);
   `:desc` puts the newest in train.
 
 # Examples
 ```julia
 # dates is both data and the ordering variable
-res = partition(dates, TimeSplitOldest(0.7))
+res = partition(dates, TimeSplitOldest(); train=70, test=30)
 train_idx, test_idx = trainindices(res), testindices(res)
 
 # X is the data to split; dates provides the ordering
-res = partition(X, TimeSplitOldest(0.7); time=dates)
+res = partition(X, TimeSplitOldest(); time=dates, train=70, test=30)
 X_train, X_test = splitdata(res, X)
 ```
 """
-struct TimeSplit{T} <: AbstractSplitStrategy
-  frac::ValidFraction{T}
+struct TimeSplit <: AbstractSplitStrategy
   order::Symbol
 end
 
-TimeSplit(frac::Real, order::Symbol = :asc) = TimeSplit(ValidFraction(frac), order)
+TimeSplit() = TimeSplit(:asc)
 
 """
-    TimeSplitOldest(frac)
+    TimeSplitOldest()
 
-Alias for `TimeSplit(frac, :asc)` — oldest observations go to the training set.
+Alias for `TimeSplit(:asc)` — oldest observations go to the training set.
 """
-TimeSplitOldest(frac::Real) = TimeSplit(frac, :asc)
+TimeSplitOldest() = TimeSplit(:asc)
 
 """
-    TimeSplitNewest(frac)
+    TimeSplitNewest()
 
-Alias for `TimeSplit(frac, :desc)` — newest observations go to the training set.
+Alias for `TimeSplit(:desc)` — newest observations go to the training set.
 """
-TimeSplitNewest(frac::Real) = TimeSplit(frac, :desc)
+TimeSplitNewest() = TimeSplit(:desc)
 
 consumes(::TimeSplit) = (:time,)
 fallback_from_data(::TimeSplit) = (:time,)
 
-function _partition(data, s::TimeSplit; time, rng = Random.GLOBAL_RNG, kwargs...)
-  N = numobs(data)
+function _partition(
+  data,
+  s::TimeSplit;
+  time,
+  n_train,
+  n_test,
+  rng = Random.GLOBAL_RNG,
+  kwargs...,
+)
   date_to_indices = Dict{eltype(time),Vector{Int}}()
   for (i, d) in enumerate(time)
     push!(get!(date_to_indices, d, Int[]), i)
@@ -56,7 +61,6 @@ function _partition(data, s::TimeSplit; time, rng = Random.GLOBAL_RNG, kwargs...
   dates = collect(keys(date_to_indices))
   descending = s.order in (:desc, :newest, :latest, :max, :maximum)
   sorted_dates = sort(dates; rev = descending)
-  n_train, _ = train_test_counts(N, s.frac)
   total = 0
   train_idx = Int[]
   test_idx = Int[]

--- a/src/strategies/random.jl
+++ b/src/strategies/random.jl
@@ -1,31 +1,23 @@
 using Random
 
 """
-    RandomSplit{T} <: AbstractSplitStrategy
+    RandomSplit <: AbstractSplitStrategy
 
-Randomly splits data into train/test sets.
-
-# Fields
-- `frac::ValidFraction{T}`: Fraction of data to use for training (0 < frac < 1)
+Randomly splits data into the requested cohort sizes.
 
 # Examples
 ```julia
-res = partition(X, RandomSplit(0.8))
+res = partition(X, RandomSplit(); train = 80, test = 20)
 X_train, X_test = splitdata(res, X)
 ```
 """
-struct RandomSplit{T} <: AbstractSplitStrategy
-  frac::ValidFraction{T}
-end
-
-RandomSplit(frac::Real) = RandomSplit(ValidFraction(frac))
+struct RandomSplit <: AbstractSplitStrategy end
 
 consumes(::RandomSplit) = ()
 fallback_from_data(::RandomSplit) = ()
 
-function _partition(data, s::RandomSplit; rng, kwargs...)
+function _partition(data, ::RandomSplit; n_train, n_test, rng, kwargs...)
   N = numobs(data)
   perm = randperm(rng, N)
-  cut = floor(Int, s.frac * N)
-  return TrainTestSplit(perm[1:cut], perm[cut+1:end])
+  return TrainTestSplit(perm[1:n_train], perm[(n_train+1):end])
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -118,4 +118,3 @@ Error thrown when a required split method or feature is not implemented.
 struct SplitNotImplementedError <: Exception
   msg::String
 end
-

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -119,31 +119,3 @@ struct SplitNotImplementedError <: Exception
   msg::String
 end
 
-
-
-"""
-    train_test_counts(N, frac; min_train=2, min_test=2)
-
-Given total sample count `N` and train fraction `frac`, return `(n_train, n_test)`.
-Throws `SplitParameterError` if the split is not possible (e.g., too few samples, fraction out of bounds).
-"""
-function train_test_counts(N::Integer, frac; min_train::Integer = 1, min_test::Integer = 1)
-  if N < min_train + min_test
-    throw(
-      SplitParameterError(
-        "Not enough samples ($N) to split: need at least $(min_train + min_test).",
-      ),
-    )
-  end
-  n_train = round(Int, frac * N)
-  n_test = N - n_train
-
-  if n_train < min_train || n_test < min_test
-    throw(
-      SplitParameterError(
-        "Split would result in too few samples: n_train=$n_train, n_test=$n_test (min_train=$min_train, min_test=$min_test).",
-      ),
-    )
-  end
-  return n_train, n_test
-end

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -1,0 +1,68 @@
+
+"""
+    ValidFraction{T<:Real}
+
+A wrapper type guaranteeing a real value strictly in (0, 1).
+
+Arithmetic with plain numbers delegates to the underlying value so it can be
+used transparently in formulas.
+"""
+struct ValidFraction{T<:Real}
+  frac::T
+  function ValidFraction(frac::T) where {T<:Real}
+    _is_fraction(frac) ||
+      throw(SplitParameterError("Fraction must be strictly between 0 and 1. Got $frac."))
+    new{T}(frac)
+  end
+end
+
+Base.:*(vf::ValidFraction, x::Number) = vf.frac * x
+Base.:*(x::Number, vf::ValidFraction) = x * vf.frac
+Base.:+(x::Number, vf::ValidFraction) = x + vf.frac
+Base.:+(x::ValidFraction, y::ValidFraction) = x.frac + y.frac
+Base.:+(x::ValidFraction, y::Number) = x.frac + y
+Base.:-(x::Number, vf::ValidFraction) = x - vf.frac
+Base.float(vf::ValidFraction) = vf.frac
+Base.convert(::Type{T}, vf::ValidFraction) where {T<:Number} = convert(T, vf.frac)
+
+
+_as_valid_fraction(x::ValidFraction) = x
+_as_valid_fraction(x::Real) = ValidFraction(x)
+_as_valid_fraction(::Nothing) = nothing
+
+"""
+Check whether a number is strictly in (0, 1).
+"""
+_is_fraction(x::Real) = 0 < x < 1
+
+"""
+    _assert_unit_fraction_sum(fractions::ValidFraction...)
+
+Assert that the supplied validated fractions form a complete partition.
+
+Throws `SplitParameterError` if the sum of the wrapped fraction values is not
+approximately equal to `1`.
+"""
+function _assert_unit_fraction_sum(fractions::Union{ValidFraction,Nothing}...)
+  s = sum(float, filter(!isnothing, fractions))
+
+  isapprox(s, one(s)) ||
+    throw(SplitParameterError("Fractional cohort sizes must sum to 1.0; got $s."))
+
+  return nothing
+end
+
+function _assert_positive_integer(name::Symbol, value::Integer)
+  value >= 1 ||
+    throw(SplitParameterError("`$name` must be a positive integer, got $value."))
+
+  return nothing
+end
+
+function _assert_positive_integer_parts(parts::Pair{Symbol,<:Integer}...)
+  for (name, value) in parts
+    _assert_positive_integer(name, value)
+  end
+
+  return nothing
+end

--- a/test/test-group-shuffle-split.jl
+++ b/test/test-group-shuffle-split.jl
@@ -43,7 +43,8 @@ end
 
 @testset "GroupShuffleSplit fallback: ids as both data and groups" begin
   ids = vcat(fill(:a, 40), fill(:b, 40), fill(:c, 40))
-  result = partition(ids, GroupShuffleSplit(); train = 60, test = 40, rng = MersenneTwister(42))
+  result =
+    partition(ids, GroupShuffleSplit(); train = 60, test = 40, rng = MersenneTwister(42))
   @test length(result.train) + length(result.test) == 120
   @test isempty(intersect(result.train, result.test))
 end

--- a/test/test-group-shuffle-split.jl
+++ b/test/test-group-shuffle-split.jl
@@ -7,7 +7,14 @@ N = 120
 @testset "GroupShuffleSplit with explicit groups" begin
   groups = vcat(fill(1, 30), fill(2, 40), fill(3, 50))
 
-  result = partition(X, GroupShuffleSplit(0.5); groups = groups, rng = MersenneTwister(123))
+  result = partition(
+    X,
+    GroupShuffleSplit();
+    groups = groups,
+    train = 50,
+    test = 50,
+    rng = MersenneTwister(123),
+  )
   train, test = result.train, result.test
   @test length(train) + length(test) == N
   @test abs(length(train) / N - 0.5) < 0.2
@@ -21,8 +28,14 @@ N = 120
     @test in_train == 0 || in_test == 0
   end
 
-  result2 =
-    partition(X, GroupShuffleSplit(0.6); groups = groups, rng = MersenneTwister(123))
+  result2 = partition(
+    X,
+    GroupShuffleSplit();
+    groups = groups,
+    train = 60,
+    test = 40,
+    rng = MersenneTwister(123),
+  )
   train2, test2 = result2.train, result2.test
   @test length(train2) + length(test2) == N
   @test abs(length(train2) / N - 0.6) < 0.2
@@ -30,7 +43,7 @@ end
 
 @testset "GroupShuffleSplit fallback: ids as both data and groups" begin
   ids = vcat(fill(:a, 40), fill(:b, 40), fill(:c, 40))
-  result = partition(ids, GroupShuffleSplit(0.6); rng = MersenneTwister(42))
+  result = partition(ids, GroupShuffleSplit(); train = 60, test = 40, rng = MersenneTwister(42))
   @test length(result.train) + length(result.test) == 120
   @test isempty(intersect(result.train, result.test))
 end
@@ -39,8 +52,10 @@ end
   res_k = kmeans(X, 3)
   result = partition(
     X,
-    GroupShuffleSplit(0.7);
+    GroupShuffleSplit();
     groups = assignments(res_k),
+    train = 70,
+    test = 30,
     rng = MersenneTwister(1),
   )
   @test length(result.train) + length(result.test) == N

--- a/test/test-group-stratified-split.jl
+++ b/test/test-group-stratified-split.jl
@@ -7,8 +7,8 @@ import DataSplits: SplitInputError, SplitParameterError
   groups = vcat(fill(1, 5), fill(2, 5), fill(3, 5))
 
   @testset "Proportional allocation" begin
-    s = GroupStratifiedSplit(:proportional; frac = 0.5)
-    result = partition(X, s; groups = groups)
+    s = GroupStratifiedSplit(:proportional)
+    result = partition(X, s; groups = groups, train = 50, test = 50)
     train, test = result.train, result.test
     @test length(train) + length(test) == 15
     @test isempty(intersect(train, test))
@@ -20,28 +20,28 @@ import DataSplits: SplitInputError, SplitParameterError
   end
 
   @testset "Equal allocation" begin
-    s = GroupStratifiedSplit(:equal; n = 4, frac = 0.5)
-    result = partition(X, s; groups = groups)
+    s = GroupStratifiedSplit(:equal; n = 4)
+    result = partition(X, s; groups = groups, train = 50, test = 50)
     train, test = result.train, result.test
     @test length(train) + length(test) <= 12   # at most 4 per cluster × 3
     @test isempty(intersect(train, test))
   end
 
   @testset "Neyman allocation" begin
-    s = GroupStratifiedSplit(:neyman; n = 4, frac = 0.5)
-    result = partition(X, s; groups = groups)
+    s = GroupStratifiedSplit(:neyman; n = 4)
+    result = partition(X, s; groups = groups, train = 50, test = 50)
     train, test = result.train, result.test
     @test length(train) + length(test) <= 15
     @test isempty(intersect(train, test))
   end
 
   @testset "Unknown allocation raises error" begin
-    s = GroupStratifiedSplit(:bogus; frac = 0.5)
-    @test_throws SplitParameterError partition(X, s; groups = groups)
+    s = GroupStratifiedSplit(:bogus)
+    @test_throws SplitParameterError partition(X, s; groups = groups, train = 50, test = 50)
   end
 
   @testset "Fallback: groups as both data and groups" begin
-    result = partition(groups, GroupStratifiedSplit(:proportional; frac = 0.6))
+    result = partition(groups, GroupStratifiedSplit(:proportional); train = 60, test = 40)
     @test length(result.train) + length(result.test) == 15
     @test isempty(intersect(result.train, result.test))
   end

--- a/test/test-kennard_stone.jl
+++ b/test/test-kennard_stone.jl
@@ -15,31 +15,44 @@ function check_split(result, N; n_test_expected = nothing)
   end
 end
 
-function standard_kennard_tests(split_fn, X, Xv)
+# Helper: convert (frac, metric) into the new (train_pct, test_pct) form.
+function _pct(frac)
+  train = round(Int, frac * 100)
+  test = 100 - train
+  return train, test
+end
+
+function standard_kennard_tests(strategy_fn, X, Xv)
   Random.seed!(42)
 
-  result = split_fn(X, 0.8, Euclidean())
+  function call(X, frac, metric; rng = Random.GLOBAL_RNG)
+    train, test = _pct(frac)
+    return DataSplits.partition(X, strategy_fn(metric); train, test, rng)
+  end
+
+  result = call(X, 0.8, Euclidean())
   check_split(result, 50; n_test_expected = 10)
 
-  result2 = split_fn(Xv, 0.3, CosineDist())
+  result2 = call(Xv, 0.3, CosineDist())
   check_split(result2, 50; n_test_expected = 35)
 
   rng1 = MersenneTwister(123)
-  result1 = split_fn(X, 0.25, Euclidean(); rng = rng1)
+  result1 = call(X, 0.25, Euclidean(); rng = rng1)
   tr1, te1 = result1.train, result1.test
   rng2 = MersenneTwister(123)
-  result2b = split_fn(X, 0.25, Euclidean(); rng = rng2)
+  result2b = call(X, 0.25, Euclidean(); rng = rng2)
   tr2b, te2b = result2b.train, result2b.test
   @test tr1 == tr2b && te1 == te2b
 
-  @test_throws SplitParameterError split_fn(rand(2, 10), 0.02, Euclidean())
-  @test_throws SplitParameterError split_fn(rand(2, 10), 0.98, Euclidean())
-  @test_throws SplitParameterError split_fn(rand(5, 5), 0.0, Euclidean())
-  @test_throws SplitParameterError split_fn(rand(5, 5), 1.0, Euclidean())
+  # Resolved counts < 1 must be rejected
+  @test_throws SplitParameterError call(rand(2, 10), 0.02, Euclidean())
+  @test_throws SplitParameterError call(rand(2, 10), 0.98, Euclidean())
+  @test_throws SplitParameterError call(rand(5, 5), 0.0, Euclidean())
+  @test_throws SplitParameterError call(rand(5, 5), 1.0, Euclidean())
 
   X2 = vcat(randn(5, 2) .+ 5, randn(5, 2) .- 5)'
   labels = [x[1] > 0 ? 1 : -1 for x in getobs(X2)]
-  result_small = split_fn(X2, 0.2, Euclidean())
+  result_small = call(X2, 0.2, Euclidean())
   test_labels = getobs(labels, result_small.test)
   @test 1 in test_labels
   @test -1 in test_labels
@@ -48,9 +61,16 @@ function standard_kennard_tests(split_fn, X, Xv)
   X = npzread(joinpath(data_dir, "kennard-stone-data.npy"))'
   train_idx_py = npzread(joinpath(data_dir, "kennard-stone-train-id.npy")) .+ 1
 
-  result_py = split_fn(X, 0.75, Euclidean())
+  N = numobs(X)
+  n_train_py = length(train_idx_py)
+  result_py = DataSplits.partition(
+    X,
+    strategy_fn(Euclidean());
+    train = n_train_py,
+    test = N - n_train_py,
+  )
   train, test = result_py.train, result_py.test
-  @test length(train) == length(train_idx_py)
+  @test length(train) == n_train_py
   @test sort(train) == train_idx_py
 end
 
@@ -60,10 +80,7 @@ end
   X = rand(3, 50)
   Xv = [X[:, i] for i = 1:size(X, 2)]
 
-  split_fn(X, frac, metric; rng = Random.GLOBAL_RNG) =
-    DataSplits.partition(X, LazyKennardStoneSplit(frac, metric); rng = rng)
-
-  standard_kennard_tests(split_fn, X, Xv)
+  standard_kennard_tests(metric -> LazyKennardStoneSplit(metric), X, Xv)
 end
 
 @testset "In Memory Kennard Stone" begin
@@ -71,10 +88,7 @@ end
   X = rand(3, 50)
   Xv = [X[:, i] for i = 1:size(X, 2)]
 
-  split_fn(X, frac, metric; rng = Random.GLOBAL_RNG) =
-    DataSplits.partition(X, KennardStoneSplit(frac, metric); rng = rng)
-
-  standard_kennard_tests(split_fn, X, Xv)
+  standard_kennard_tests(metric -> KennardStoneSplit(metric), X, Xv)
 end
 
 @testset "Kennard Stone Consistency" begin
@@ -83,11 +97,12 @@ end
 
   for frac in [0.2, 0.5, 0.8]
     for metric in [Euclidean(), CosineDist()]
-      strat1 = KennardStoneSplit(frac, metric)
-      strat2 = LazyKennardStoneSplit(frac, metric)
+      strat1 = KennardStoneSplit(metric)
+      strat2 = LazyKennardStoneSplit(metric)
+      train_pct, test_pct = _pct(frac)
 
-      result1 = DataSplits.partition(X, strat1)
-      result2 = DataSplits.partition(X, strat2)
+      result1 = DataSplits.partition(X, strat1; train = train_pct, test = test_pct)
+      result2 = DataSplits.partition(X, strat2; train = train_pct, test = test_pct)
 
       @test Set(result1.train) == Set(result2.train)
       @test Set(result1.test) == Set(result2.test)

--- a/test/test-lazy-mdks.jl
+++ b/test/test-lazy-mdks.jl
@@ -15,21 +15,31 @@ import DataSplits: SplitInputError
   ]'
   y = [4, 1, 7, 5, 2, 5]
 
-  @test_throws SplitInputError partition(X, LazyMDKSSplit(0.7))
+  @test_throws SplitInputError partition(X, LazyMDKSSplit(); train = 70, test = 30)
 
-  result = partition(X, LazyMDKSSplit(0.7); target = y)
+  result = partition(X, LazyMDKSSplit(); target = y, train = 70, test = 30)
   train_idx, test_idx = result.train, result.test
   @test length(train_idx) + length(test_idx) == length(y)
   @test isempty(intersect(train_idx, test_idx))
 
-  result2 =
-    partition(X, LazyMDKSSplit(0.7; metric = Mahalanobis(cov(X; dims = 2))); target = y)
+  result2 = partition(
+    X,
+    LazyMDKSSplit(; metric = Mahalanobis(cov(X; dims = 2)));
+    target = y,
+    train = 70,
+    test = 30,
+  )
   train_idx2, test_idx2 = result2.train, result2.test
   @test length(train_idx2) + length(test_idx2) == length(y)
   @test isempty(intersect(train_idx2, test_idx2))
 
-  result_mdks =
-    partition(X, MDKSSplit(0.7; metric = Mahalanobis(cov(X; dims = 2))); target = y)
+  result_mdks = partition(
+    X,
+    MDKSSplit(; metric = Mahalanobis(cov(X; dims = 2)));
+    target = y,
+    train = 70,
+    test = 30,
+  )
   @test Set(train_idx2) == Set(result_mdks.train)
   @test Set(test_idx2) == Set(result_mdks.test)
   @test isempty(intersect(result_mdks.train, result_mdks.test))

--- a/test/test-lazy-optisim.jl
+++ b/test/test-lazy-optisim.jl
@@ -10,6 +10,12 @@ function sane_split_check(result, N; ntrain_expected = nothing)
   ntrain_expected === nothing || @test length(train) == ntrain_expected
 end
 
+function _pct(frac)
+  train = round(Int, frac * 100)
+  test = 100 - train
+  return train, test
+end
+
 function make_split(
   X;
   frac = 0.7,
@@ -18,14 +24,16 @@ function make_split(
   distance_cutoff = 0.5,
   rng = Random.GLOBAL_RNG,
 )
+  train, test = _pct(frac)
   return DataSplits.partition(
     X,
-    LazyOptiSimSplit(
-      frac;
+    LazyOptiSimSplit(;
       max_subsample_size = max_subsample_size,
       distance_cutoff = distance_cutoff,
       metric = metric,
     );
+    train = train,
+    test = test,
     rng = rng,
   )
 end
@@ -43,12 +51,13 @@ end
 
   result = DataSplits.partition(
     X,
-    LazyOptiSimSplit(
-      0.75;
+    LazyOptiSimSplit(;
       max_subsample_size = 3,
       distance_cutoff = 0.35,
       metric = Euclidean(),
-    ),
+    );
+    train = 80,
+    test = 20,
     rng = Random.seed!(42),
   )
   train_idx, test_idx = result.train, result.test
@@ -63,12 +72,13 @@ end
   rng1 = MersenneTwister(123)
   result = DataSplits.partition(
     X,
-    LazyOptiSimSplit(
-      0.6;
+    LazyOptiSimSplit(;
       max_subsample_size = 3,
       distance_cutoff = 0.35,
       metric = Euclidean(),
-    ),
+    );
+    train = 60,
+    test = 40,
     rng = rng1,
   )
   t1a, te1a = result.train, result.test
@@ -76,7 +86,9 @@ end
   rng2 = MersenneTwister(123)
   result = DataSplits.partition(
     X,
-    OptiSimSplit(0.6; max_subsample_size = 3, distance_cutoff = 0.35, metric = Euclidean()),
+    OptiSimSplit(; max_subsample_size = 3, distance_cutoff = 0.35, metric = Euclidean());
+    train = 60,
+    test = 40,
     rng = rng2,
   )
   @test t1a == result.train

--- a/test/test-lazy-spxy.jl
+++ b/test/test-lazy-spxy.jl
@@ -15,21 +15,23 @@ import DataSplits: SplitInputError, SplitParameterError, SplitNotImplementedErro
   ]'
   y = [4, 1, 7, 5, 2, 5]
 
-  @test_throws SplitInputError partition(X, LazySPXYSplit(0.7))
+  @test_throws SplitInputError partition(X, LazySPXYSplit(); train = 70, test = 30)
 
-  result = partition(X, LazySPXYSplit(0.7); target = y)
+  result = partition(X, LazySPXYSplit(); target = y, train = 70, test = 30)
   train_idx, test_idx = result.train, result.test
 
   result2 = partition(
     X,
-    LazySPXYSplit(0.7; metric_X = Cityblock(), metric_y = Euclidean());
+    LazySPXYSplit(; metric_X = Cityblock(), metric_y = Euclidean());
     target = y,
+    train = 70,
+    test = 30,
   )
   train_idx2, test_idx2 = result2.train, result2.test
   @test length(train_idx2) + length(test_idx2) == length(y)
   @test isempty(intersect(train_idx2, test_idx2))
 
-  result_spxy = partition(X, SPXYSplit(0.7); target = y)
+  result_spxy = partition(X, SPXYSplit(); target = y, train = 70, test = 30)
   @test Set(train_idx) == Set(result_spxy.train)
   @test Set(test_idx) == Set(result_spxy.test)
   @test isempty(intersect(train_idx, test_idx))

--- a/test/test-minmax-dissimilarity.jl
+++ b/test/test-minmax-dissimilarity.jl
@@ -15,7 +15,9 @@ using Distances
   # Maximum Dissimilarity
   result_max = DataSplits.partition(
     X,
-    MaximumDissimilaritySplit(0.6; distance_cutoff = 0.0, metric = Euclidean()),
+    MaximumDissimilaritySplit(; distance_cutoff = 0.0, metric = Euclidean());
+    train = 60,
+    test = 40,
     rng = Random.seed!(42),
   )
   train_max, test_max = result_max.train, result_max.test
@@ -26,7 +28,9 @@ using Distances
   # Minimum Dissimilarity
   result_min = DataSplits.partition(
     X,
-    MinimumDissimilaritySplit(0.6; distance_cutoff = 0.0, metric = Euclidean()),
+    MinimumDissimilaritySplit(; distance_cutoff = 0.0, metric = Euclidean());
+    train = 60,
+    test = 40,
     rng = Random.seed!(42),
   )
   train_min, test_min = result_min.train, result_min.test
@@ -48,7 +52,9 @@ end
   # Maximum Dissimilarity
   result_max = DataSplits.partition(
     X,
-    LazyMaximumDissimilaritySplit(0.6; distance_cutoff = 0.0, metric = Euclidean()),
+    LazyMaximumDissimilaritySplit(; distance_cutoff = 0.0, metric = Euclidean());
+    train = 60,
+    test = 40,
     rng = Random.seed!(42),
   )
   train_max, test_max = result_max.train, result_max.test
@@ -59,7 +65,9 @@ end
   # Minimum Dissimilarity
   result_min = DataSplits.partition(
     X,
-    LazyMinimumDissimilaritySplit(0.6; distance_cutoff = 0.0, metric = Euclidean()),
+    LazyMinimumDissimilaritySplit(; distance_cutoff = 0.0, metric = Euclidean());
+    train = 60,
+    test = 40,
     rng = Random.seed!(42),
   )
   train_min, test_min = result_min.train, result_min.test

--- a/test/test-morais-lima-martin-split.jl
+++ b/test/test-morais-lima-martin-split.jl
@@ -38,5 +38,5 @@ using Test
   @test r1.train == r2.train
   @test r1.test == r2.test
 
-  @test_throws SplitParameterError MoraisLimaMartinSplit(; swap_frac = 1.0)
+  @test_throws SplitParameterError MoraisLimaMartinSplit(; swap_frac = 1.5)
 end

--- a/test/test-morais-lima-martin-split.jl
+++ b/test/test-morais-lima-martin-split.jl
@@ -9,7 +9,9 @@ using Test
   rng = MersenneTwister(123)
   result1 = partition(
     X,
-    MoraisLimaMartinSplit(0.8; swap_frac = 0.1, metric = Euclidean());
+    MoraisLimaMartinSplit(; swap_frac = 0.1, metric = Euclidean());
+    train = 80,
+    test = 20,
     rng = rng,
   )
   train, test = result1.train, result1.test
@@ -18,11 +20,23 @@ using Test
 
   # Determinism
   rng1 = MersenneTwister(42)
-  r1 = partition(X, MoraisLimaMartinSplit(0.5; swap_frac = 0.2); rng = rng1)
+  r1 = partition(
+    X,
+    MoraisLimaMartinSplit(; swap_frac = 0.2);
+    train = 50,
+    test = 50,
+    rng = rng1,
+  )
   rng2 = MersenneTwister(42)
-  r2 = partition(X, MoraisLimaMartinSplit(0.5; swap_frac = 0.2); rng = rng2)
+  r2 = partition(
+    X,
+    MoraisLimaMartinSplit(; swap_frac = 0.2);
+    train = 50,
+    test = 50,
+    rng = rng2,
+  )
   @test r1.train == r2.train
   @test r1.test == r2.test
 
-  @test_throws SplitParameterError MoraisLimaMartinSplit(0.5; swap_frac = 1.0)
+  @test_throws SplitParameterError MoraisLimaMartinSplit(; swap_frac = 1.0)
 end

--- a/test/test-optisim.jl
+++ b/test/test-optisim.jl
@@ -10,6 +10,12 @@ function sane_split_check(result, N; ntrain_expected = nothing)
   ntrain_expected === nothing || @test length(train) == ntrain_expected
 end
 
+function _pct(frac)
+  train = round(Int, frac * 100)
+  test = 100 - train
+  return train, test
+end
+
 function make_split(
   X;
   frac = 0.7,
@@ -18,14 +24,16 @@ function make_split(
   distance_cutoff = 0.5,
   rng = Random.GLOBAL_RNG,
 )
+  train, test = _pct(frac)
   return DataSplits.partition(
     X,
-    OptiSimSplit(
-      frac;
+    OptiSimSplit(;
       max_subsample_size = max_subsample_size,
       distance_cutoff = distance_cutoff,
       metric = metric,
     );
+    train = train,
+    test = test,
     rng = rng,
   )
 end
@@ -43,12 +51,13 @@ end
 
   result = DataSplits.partition(
     X,
-    OptiSimSplit(
-      0.75;
+    OptiSimSplit(;
       max_subsample_size = 3,
       distance_cutoff = 0.35,
       metric = Euclidean(),
-    ),
+    );
+    train = 80,
+    test = 20,
     rng = Random.seed!(42),
   )
   train_idx, test_idx = result.train, result.test
@@ -63,7 +72,13 @@ end
   rng1 = MersenneTwister(123)
   result = DataSplits.partition(
     X,
-    OptiSimSplit(0.6; max_subsample_size = 3, distance_cutoff = 0.35, metric = Euclidean()),
+    OptiSimSplit(;
+      max_subsample_size = 3,
+      distance_cutoff = 0.35,
+      metric = Euclidean(),
+    );
+    train = 60,
+    test = 40,
     rng = rng1,
   )
   t1a, te1a = result.train, result.test

--- a/test/test-optisim.jl
+++ b/test/test-optisim.jl
@@ -51,11 +51,7 @@ end
 
   result = DataSplits.partition(
     X,
-    OptiSimSplit(;
-      max_subsample_size = 3,
-      distance_cutoff = 0.35,
-      metric = Euclidean(),
-    );
+    OptiSimSplit(; max_subsample_size = 3, distance_cutoff = 0.35, metric = Euclidean());
     train = 80,
     test = 20,
     rng = Random.seed!(42),
@@ -72,11 +68,7 @@ end
   rng1 = MersenneTwister(123)
   result = DataSplits.partition(
     X,
-    OptiSimSplit(;
-      max_subsample_size = 3,
-      distance_cutoff = 0.35,
-      metric = Euclidean(),
-    );
+    OptiSimSplit(; max_subsample_size = 3, distance_cutoff = 0.35, metric = Euclidean());
     train = 60,
     test = 40,
     rng = rng1,

--- a/test/test-partition-validation.jl
+++ b/test/test-partition-validation.jl
@@ -134,23 +134,7 @@ import DataSplits: SplitInputError, SplitParameterError, SplitNotImplementedErro
   end
 
   @testset "input validation" begin
-    # validation kwarg without second strategy
-    @test_throws SplitInputError partition(
-      X,
-      RandomSplit();
-      train = 70,
-      validation = 10,
-      test = 20,
-    )
-    # second strategy without validation kwarg
-    @test_throws SplitInputError partition(
-      X,
-      RandomSplit(),
-      RandomSplit();
-      train = 70,
-      test = 30,
-    )
-    # bad sum
+    # bad sum (three-cohort)
     @test_throws SplitParameterError partition(
       X,
       RandomSplit(),
@@ -159,5 +143,37 @@ import DataSplits: SplitInputError, SplitParameterError, SplitNotImplementedErro
       validation = 10,
       test = 30,
     )
+    # empty data
+    @test_throws SplitInputError partition(
+      zeros(3, 0),
+      RandomSplit();
+      train = 70,
+      test = 30,
+    )
+  end
+
+  @testset "float fractions" begin
+    res = partition(
+      X,
+      RandomSplit();
+      train = 0.7,
+      test = 0.3,
+      rng = MersenneTwister(10),
+    )
+    @test length(res.train) == 70
+    @test length(res.test) == 30
+
+    res3 = partition(
+      X,
+      RandomSplit(),
+      RandomSplit();
+      train = 0.7,
+      validation = 0.1,
+      test = 0.2,
+      rng = MersenneTwister(11),
+    )
+    @test length(res3.train) == 70
+    @test length(res3.val) == 10
+    @test length(res3.test) == 20
   end
 end

--- a/test/test-partition-validation.jl
+++ b/test/test-partition-validation.jl
@@ -1,0 +1,163 @@
+using Test
+using Random
+using Distances
+using DataSplits
+import DataSplits: SplitInputError, SplitParameterError, SplitNotImplementedError
+
+@testset "partition: train/validation/test" begin
+  Random.seed!(42)
+  N = 100
+  X = rand(3, N)
+  y = randn(N)
+  groups = repeat(1:10, inner = 10)
+  dates = repeat(1:10, inner = 10)
+
+  @testset "two RandomSplit strategies, percentages" begin
+    res = partition(
+      X,
+      RandomSplit(),
+      RandomSplit();
+      train = 70,
+      validation = 10,
+      test = 20,
+      rng = MersenneTwister(1),
+    )
+    @test res isa DataSplits.TrainValTestSplit
+    train, val, test = res.train, res.val, res.test
+    @test length(train) == 70
+    @test length(val) == 10
+    @test length(test) == 20
+    @test isempty(intersect(train, val))
+    @test isempty(intersect(train, test))
+    @test isempty(intersect(val, test))
+    @test sort(vcat(train, val, test)) == 1:N
+  end
+
+  @testset "two RandomSplit strategies, absolute counts" begin
+    res = partition(
+      X,
+      RandomSplit(),
+      RandomSplit();
+      train = 65,
+      validation = 15,
+      test = 20,
+      rng = MersenneTwister(2),
+    )
+    @test length(res.train) == 65
+    @test length(res.val) == 15
+    @test length(res.test) == 20
+  end
+
+  @testset "splitdata returns 3-tuple" begin
+    res = partition(
+      X,
+      RandomSplit(),
+      RandomSplit();
+      train = 70,
+      validation = 10,
+      test = 20,
+      rng = MersenneTwister(3),
+    )
+    Xtr, Xv, Xte = splitdata(res, X)
+    @test size(Xtr, 2) == 70
+    @test size(Xv, 2) == 10
+    @test size(Xte, 2) == 20
+  end
+
+  @testset "mixed slot consumers" begin
+    # outer consumes :time, inner consumes :target
+    res = partition(
+      X,
+      TimeSplitOldest(),
+      TargetPropertyHigh();
+      time = dates,
+      target = y,
+      train = 60,
+      validation = 20,
+      test = 20,
+      rng = MersenneTwister(4),
+    )
+    @test res isa DataSplits.TrainValTestSplit
+    @test length(res.train) + length(res.val) + length(res.test) == N
+    @test isempty(intersect(res.train, res.val))
+    @test isempty(intersect(res.train, res.test))
+    @test isempty(intersect(res.val, res.test))
+    # Test cohort is the most-recent dates (TimeSplitOldest pushes oldest to train pool)
+    pool = vcat(res.train, res.val)
+    @test maximum(dates[res.test]) >= minimum(dates[pool])
+  end
+
+  @testset "group-aware composition keeps groups whole" begin
+    res = partition(
+      X,
+      GroupShuffleSplit(),
+      GroupShuffleSplit();
+      groups = groups,
+      train = 60,
+      validation = 20,
+      test = 20,
+      rng = MersenneTwister(5),
+    )
+    for gid in unique(groups)
+      idxs = findall(==(gid), groups)
+      hits = (
+        any(i -> i in res.train, idxs),
+        any(i -> i in res.val, idxs),
+        any(i -> i in res.test, idxs),
+      )
+      @test count(hits) == 1
+    end
+  end
+
+  @testset "reproducibility under fixed rng" begin
+    res1 = partition(
+      X,
+      RandomSplit(),
+      KennardStoneSplit();
+      train = 70,
+      validation = 10,
+      test = 20,
+      rng = MersenneTwister(123),
+    )
+    res2 = partition(
+      X,
+      RandomSplit(),
+      KennardStoneSplit();
+      train = 70,
+      validation = 10,
+      test = 20,
+      rng = MersenneTwister(123),
+    )
+    @test res1.train == res2.train
+    @test res1.val == res2.val
+    @test res1.test == res2.test
+  end
+
+  @testset "input validation" begin
+    # validation kwarg without second strategy
+    @test_throws SplitInputError partition(
+      X,
+      RandomSplit();
+      train = 70,
+      validation = 10,
+      test = 20,
+    )
+    # second strategy without validation kwarg
+    @test_throws SplitInputError partition(
+      X,
+      RandomSplit(),
+      RandomSplit();
+      train = 70,
+      test = 30,
+    )
+    # bad sum
+    @test_throws SplitParameterError partition(
+      X,
+      RandomSplit(),
+      RandomSplit();
+      train = 70,
+      validation = 10,
+      test = 30,
+    )
+  end
+end

--- a/test/test-partition-validation.jl
+++ b/test/test-partition-validation.jl
@@ -153,13 +153,7 @@ import DataSplits: SplitInputError, SplitParameterError, SplitNotImplementedErro
   end
 
   @testset "float fractions" begin
-    res = partition(
-      X,
-      RandomSplit();
-      train = 0.7,
-      test = 0.3,
-      rng = MersenneTwister(10),
-    )
+    res = partition(X, RandomSplit(); train = 0.7, test = 0.3, rng = MersenneTwister(10))
     @test length(res.train) == 70
     @test length(res.test) == 30
 

--- a/test/test-random.jl
+++ b/test/test-random.jl
@@ -38,11 +38,35 @@ rng = MersenneTwister(42)
   end
 
   @testset "Edge Cases" begin
-    @test_throws SplitInputError partition(zeros(2, 0), strategy; train = 60, test = 40, rng)
-    @test_throws SplitParameterError partition(rand(2, 10), strategy; train = 0, test = 100, rng)
-    @test_throws SplitParameterError partition(rand(2, 10), strategy; train = 100, test = 0, rng)
+    @test_throws SplitInputError partition(
+      zeros(2, 0),
+      strategy;
+      train = 60,
+      test = 40,
+      rng,
+    )
+    @test_throws SplitParameterError partition(
+      rand(2, 10),
+      strategy;
+      train = 0,
+      test = 100,
+      rng,
+    )
+    @test_throws SplitParameterError partition(
+      rand(2, 10),
+      strategy;
+      train = 100,
+      test = 0,
+      rng,
+    )
     # Sum neither 100 nor N
-    @test_throws SplitParameterError partition(rand(2, 10), strategy; train = 50, test = 40, rng)
+    @test_throws SplitParameterError partition(
+      rand(2, 10),
+      strategy;
+      train = 50,
+      test = 40,
+      rng,
+    )
   end
 
   @testset "Randomness" begin

--- a/test/test-random.jl
+++ b/test/test-random.jl
@@ -13,8 +13,8 @@ rng = MersenneTwister(42)
 
 @testset "partition() with RandomSplit" begin
   data_std = rand(2, 10)
-  strategy = RandomSplit(0.6)
-  result = partition(data_std, strategy; rng)
+  strategy = RandomSplit()
+  result = partition(data_std, strategy; train = 60, test = 40, rng)
   train_idx, test_idx = result.train, result.test
 
   @testset "Standard Array" begin
@@ -27,7 +27,7 @@ rng = MersenneTwister(42)
 
   @testset "Offset Array" begin
     data_offset = OffsetArray(rand(2, 10), 1:2, -5:4)
-    result = partition(data_offset, strategy; rng)
+    result = partition(data_offset, strategy; train = 60, test = 40, rng)
     train_idx, test_idx = result.train, result.test
 
     @test length(train_idx) == 6
@@ -38,23 +38,32 @@ rng = MersenneTwister(42)
   end
 
   @testset "Edge Cases" begin
-    @test_throws SplitInputError partition(zeros(2, 0), strategy; rng)
-    @test_throws SplitParameterError partition(rand(2, 10), RandomSplit(0.0); rng)
-    @test_throws SplitParameterError partition(rand(2, 10), RandomSplit(1.0); rng)
+    @test_throws SplitInputError partition(zeros(2, 0), strategy; train = 60, test = 40, rng)
+    @test_throws SplitParameterError partition(rand(2, 10), strategy; train = 0, test = 100, rng)
+    @test_throws SplitParameterError partition(rand(2, 10), strategy; train = 100, test = 0, rng)
+    # Sum neither 100 nor N
+    @test_throws SplitParameterError partition(rand(2, 10), strategy; train = 50, test = 40, rng)
   end
 
   @testset "Randomness" begin
     rng = MersenneTwister(123)
-    result = partition(data_std, strategy; rng)
+    result = partition(data_std, strategy; train = 60, test = 40, rng)
     train1, test1 = result.train, result.test
     rng = MersenneTwister(123)
-    result = partition(data_std, strategy; rng)
+    result = partition(data_std, strategy; train = 60, test = 40, rng)
     train2, test2 = result.train, result.test
     @test train1 == train2 && test1 == test2
 
     rng2 = MersenneTwister(223)
-    result = partition(data_std, strategy; rng = rng2)
+    result = partition(data_std, strategy; train = 60, test = 40, rng = rng2)
     train3, test3 = result.train, result.test
     @test train1 != train3
+  end
+
+  @testset "Absolute counts" begin
+    rng = MersenneTwister(7)
+    result = partition(data_std, strategy; train = 7, test = 3, rng)
+    @test length(result.train) == 7
+    @test length(result.test) == 3
   end
 end

--- a/test/test-result-types.jl
+++ b/test/test-result-types.jl
@@ -1,0 +1,32 @@
+using Test
+using DataSplits
+using Random
+
+@testset "show" begin
+  X = rand(3, 10)
+  res2 = partition(X, RandomSplit(); train = 80, test = 20, rng = MersenneTwister(1))
+  res3 = partition(X, RandomSplit(), RandomSplit();
+                   train = 70, validation = 10, test = 20, rng = MersenneTwister(2))
+
+  @test sprint(show, res2) == "TrainTestSplit  train: 8 obs  test: 2 obs"
+  @test sprint(show, res3) == "TrainValTestSplit  train: 7 obs  val: 1 obs  test: 2 obs"
+end
+
+@testset "iterate / destructuring" begin
+  X = rand(3, 100)
+  res2 = partition(X, RandomSplit(); train = 80, test = 20, rng = MersenneTwister(3))
+  train, test = res2
+  @test train == res2.train
+  @test test  == res2.test
+  @test length(res2) == 2
+  @test collect(res2) == [res2.train, res2.test]
+
+  res3 = partition(X, RandomSplit(), RandomSplit();
+                   train = 70, validation = 10, test = 20, rng = MersenneTwister(4))
+  train, val, test = res3
+  @test train == res3.train
+  @test val   == res3.val
+  @test test  == res3.test
+  @test length(res3) == 3
+  @test collect(res3) == [res3.train, res3.val, res3.test]
+end

--- a/test/test-result-types.jl
+++ b/test/test-result-types.jl
@@ -5,8 +5,15 @@ using Random
 @testset "show" begin
   X = rand(3, 10)
   res2 = partition(X, RandomSplit(); train = 80, test = 20, rng = MersenneTwister(1))
-  res3 = partition(X, RandomSplit(), RandomSplit();
-                   train = 70, validation = 10, test = 20, rng = MersenneTwister(2))
+  res3 = partition(
+    X,
+    RandomSplit(),
+    RandomSplit();
+    train = 70,
+    validation = 10,
+    test = 20,
+    rng = MersenneTwister(2),
+  )
 
   @test sprint(show, res2) == "TrainTestSplit  train: 8 obs  test: 2 obs"
   @test sprint(show, res3) == "TrainValTestSplit  train: 7 obs  val: 1 obs  test: 2 obs"
@@ -17,16 +24,23 @@ end
   res2 = partition(X, RandomSplit(); train = 80, test = 20, rng = MersenneTwister(3))
   train, test = res2
   @test train == res2.train
-  @test test  == res2.test
+  @test test == res2.test
   @test length(res2) == 2
   @test collect(res2) == [res2.train, res2.test]
 
-  res3 = partition(X, RandomSplit(), RandomSplit();
-                   train = 70, validation = 10, test = 20, rng = MersenneTwister(4))
+  res3 = partition(
+    X,
+    RandomSplit(),
+    RandomSplit();
+    train = 70,
+    validation = 10,
+    test = 20,
+    rng = MersenneTwister(4),
+  )
   train, val, test = res3
   @test train == res3.train
-  @test val   == res3.val
-  @test test  == res3.test
+  @test val == res3.val
+  @test test == res3.test
   @test length(res3) == 3
   @test collect(res3) == [res3.train, res3.val, res3.test]
 end

--- a/test/test-spxy.jl
+++ b/test/test-spxy.jl
@@ -18,13 +18,19 @@ import DataSplits: SplitInputError, SplitParameterError, SplitNotImplementedErro
   ]'
   y = [4, 1, 7, 5, 2, 5]
 
-  @test_throws SplitInputError partition(X, SPXYSplit(0.7))
+  # 70% train, 30% test on N=6 → n_train=4, n_test=2 (sum=100)
+  @test_throws SplitInputError partition(X, SPXYSplit(); train = 70, test = 30)
 
-  result = partition(X, SPXYSplit(0.7); target = y)
+  result = partition(X, SPXYSplit(); target = y, train = 70, test = 30)
   train_idx, test_idx = result.train, result.test
 
-  result2 =
-    partition(X, SPXYSplit(0.7; metric_X = Cityblock(), metric_y = Euclidean()); target = y)
+  result2 = partition(
+    X,
+    SPXYSplit(; metric_X = Cityblock(), metric_y = Euclidean());
+    target = y,
+    train = 70,
+    test = 30,
+  )
   train_idx2, test_idx2 = result2.train, result2.test
   @test length(train_idx2) + length(test_idx2) == length(y)
   @test isempty(intersect(train_idx2, test_idx2))
@@ -49,11 +55,16 @@ end
   ]
   y = [4, 1, 7, 5, 2]
 
-  result = partition(X, SPXYSplit(0.7); target = y)
+  result = partition(X, SPXYSplit(); target = y, train = 70, test = 30)
   train_idx, test_idx = result.train, result.test
 
-  result2 =
-    partition(X, SPXYSplit(0.7; metric_X = Cityblock(), metric_y = Euclidean()); target = y)
+  result2 = partition(
+    X,
+    SPXYSplit(; metric_X = Cityblock(), metric_y = Euclidean());
+    target = y,
+    train = 70,
+    test = 30,
+  )
   train_idx2, test_idx2 = result2.train, result2.test
   @test length(train_idx2) + length(test_idx2) == length(y)
   @test isempty(intersect(train_idx2, test_idx2))
@@ -78,15 +89,17 @@ end
   ]'
   y = [4, 1, 7, 5, 2, 5]
 
-  @test_throws SplitInputError partition(X, MDKSSplit(0.7))
+  @test_throws SplitInputError partition(X, MDKSSplit(); train = 70, test = 30)
 
-  result = partition(X, MDKSSplit(0.7); target = y)
+  result = partition(X, MDKSSplit(); target = y, train = 70, test = 30)
   train_idx, test_idx = result.train, result.test
 
   result2 = partition(
     X,
-    SPXYSplit(0.7; metric_X = Mahalanobis(cov(X; dims = 2)), metric_y = Euclidean());
+    SPXYSplit(; metric_X = Mahalanobis(cov(X; dims = 2)), metric_y = Euclidean());
     target = y,
+    train = 70,
+    test = 30,
   )
   train_idx2, test_idx2 = result2.train, result2.test
   @test length(train_idx2) + length(test_idx2) == length(y)

--- a/test/test-target-property.jl
+++ b/test/test-target-property.jl
@@ -5,21 +5,21 @@ using Test
   y = [10, 20, 30, 40, 50]
 
   # Fallback: y is both data and target
-  s_high = TargetPropertyHigh(0.6)
-  result_high = partition(y, s_high)
+  s_high = TargetPropertyHigh()
+  result_high = partition(y, s_high; train = 60, test = 40)
   train = trainindices(result_high)
   test = testindices(result_high)
   @test length(train) == 3
   @test all(y[i] >= y[j] for i in train, j in test)
 
-  s_low = TargetPropertyLow(0.6)
-  result = partition(y, s_low)
+  s_low = TargetPropertyLow()
+  result = partition(y, s_low; train = 60, test = 40)
   train, test = result.train, result.test
   @test length(train) == 3
   @test all(y[i] <= y[j] for i in train, j in test)
 
-  s_col = TargetPropertySplit(0.4, :desc)
-  result = partition(y, s_col)
+  s_col = TargetPropertySplit(:desc)
+  result = partition(y, s_col; train = 40, test = 60)
   train, test = result.train, result.test
   @test length(train) == 2
   @test all(y[i] >= y[j] for i in train, j in test)
@@ -29,7 +29,7 @@ using Test
 
   # Explicit target= keyword: split X by y values
   X = rand(3, 5)
-  result2 = partition(X, TargetPropertyHigh(0.6); target = y)
+  result2 = partition(X, TargetPropertyHigh(); target = y, train = 60, test = 40)
   @test length(trainindices(result2)) == 3
   @test isempty(intersect(result2.train, result2.test))
   # same indices as the fallback case

--- a/test/test-time-split.jl
+++ b/test/test-time-split.jl
@@ -6,8 +6,8 @@ using Test
   d = collect(Date(2020, 1, 1):Day(1):Date(2020, 1, 10))
 
   # Fallback: dates is both data and time ordering
-  s = TimeSplitOldest(0.6)
-  result = partition(d, s)
+  s = TimeSplitOldest()
+  result = partition(d, s; train = 60, test = 40)
   train, test = result.train, result.test
   @test all(d[i] <= d[j] for i in train, j in test)
   @test length(train) + length(test) == 10
@@ -15,26 +15,26 @@ using Test
 
   # Explicit time= keyword
   X = rand(3, 10)
-  result2 = partition(X, s; time = d)
+  result2 = partition(X, s; time = d, train = 60, test = 40)
   @test length(result2.train) + length(result2.test) == 10
   @test isempty(intersect(result2.train, result2.test))
 
   # All same date
   d2 = fill(Date(2020, 1, 1), 10)
-  result = partition(d2, s)
+  result = partition(d2, s; train = 60, test = 40)
   train, test = result.train, result.test
   @test (length(train) == 10 && isempty(test)) || (isempty(train) && length(test) == 10)
 
   # Ties: two groups
   d3 = vcat(fill(Date(2020, 1, 1), 5), fill(Date(2020, 1, 2), 5))
-  result = partition(d3, s)
+  result = partition(d3, s; train = 60, test = 40)
   train, test = result.train, result.test
   @test (length(train) == 5 || length(train) == 10)
   @test length(train) + length(test) == 10
 
   # Newest in train
-  s2 = TimeSplitNewest(0.5)
-  result = partition(d, s2)
+  s2 = TimeSplitNewest()
+  result = partition(d, s2; train = 50, test = 50)
   train, test = result.train, result.test
   @test all(d[i] >= d[j] for i in train, j in test)
 end

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -30,3 +30,34 @@ import DataSplits: ValidFraction
   # Resolved n_train < 1 (1% of 10 = 0)
   @test_throws SplitParameterError DataSplits._resolve_sizes(10, 1, nothing, 99)
 end
+@testset "_resolve_sizes (fractions)" begin
+  @test DataSplits._resolve_sizes(10, 0.7, nothing, 0.3) == (7, 0, 3)
+  @test DataSplits._resolve_sizes(100, 0.7, 0.1, 0.2) == (70, 10, 20)
+  @test DataSplits._resolve_sizes(200, 0.8, nothing, 0.2) == (160, 0, 40)
+
+  # Floating-point imprecision tolerated
+  @test DataSplits._resolve_sizes(10, 0.1 + 0.2, nothing, 0.7) == (3, 0, 7)
+
+  # Out-of-range fractions
+  @test_throws SplitParameterError DataSplits._resolve_sizes(10, 0.0, nothing, 1.0)
+  @test_throws SplitParameterError DataSplits._resolve_sizes(10, 1.0, nothing, 0.0)
+
+  # Sum ≠ 1
+  @test_throws SplitParameterError DataSplits._resolve_sizes(10, 0.5, nothing, 0.6)
+
+  # Resolved cohort < 1 (0.01 * 10 rounds to 0)
+  @test_throws SplitParameterError DataSplits._resolve_sizes(10, 0.01, nothing, 0.99)
+end
+
+@testset "ValidFraction" begin
+  vf = ValidFraction(0.8)
+  @test vf.frac == 0.8
+  @test vf * 10 ≈ 8.0
+  @test 10 * vf ≈ 8.0
+  @test float(vf) == 0.8
+  @test convert(Float64, vf) == 0.8
+  @test_throws SplitParameterError ValidFraction(0.0)
+  @test_throws SplitParameterError ValidFraction(1.0)
+  @test_throws SplitParameterError ValidFraction(-0.1)
+  @test_throws SplitParameterError ValidFraction(1.5)
+end

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -1,25 +1,32 @@
 using Test
-using DataSplits: train_test_counts, SplitParameterError, ValidFraction
+using DataSplits: SplitParameterError
+import DataSplits
 
-@testset "train_test_counts" begin
-  # Normal case
-  @test train_test_counts(10, 0.7) == (7, 3)
-  @test train_test_counts(10, 0.3) == (3, 7)
-  # Edge: minimum allowed
-  @test train_test_counts(4, 0.5) == (2, 2)
-  # Throws if not enough samples
-  @test_throws SplitParameterError train_test_counts(1, 0.5)
-  # Throws if fraction out of bounds
-  @test_throws SplitParameterError train_test_counts(10, 0.0)
-  @test_throws SplitParameterError train_test_counts(10, 1.0)
-  @test_throws SplitParameterError train_test_counts(10, -0.1)
-  @test_throws SplitParameterError train_test_counts(10, 1.1)
-  # Throws if split would result in too few samples
-  @test_throws SplitParameterError train_test_counts(10, 0.01)
-  @test_throws SplitParameterError train_test_counts(10, 0.95)
-  # Custom minimums
-  @test train_test_counts(10, 0.6; min_train = 3, min_test = 3) == (6, 4)
-  @test_throws SplitParameterError train_test_counts(5, 0.6; min_train = 3, min_test = 3)
-  # Works with ValidFraction
-  @test train_test_counts(10, ValidFraction(0.7)) == (7, 3)
+@testset "_resolve_sizes" begin
+  # Percentages (sum to 100)
+  @test DataSplits._resolve_sizes(10, 70, nothing, 30) == (7, 0, 3)
+  @test DataSplits._resolve_sizes(10, 30, nothing, 70) == (3, 0, 7)
+  @test DataSplits._resolve_sizes(200, 80, nothing, 20) == (160, 0, 40)
+  @test DataSplits._resolve_sizes(100, 70, 10, 20) == (70, 10, 20)
+  @test DataSplits._resolve_sizes(200, 70, 10, 20) == (140, 20, 40)
+
+  # Absolute counts (sum to N)
+  @test DataSplits._resolve_sizes(10, 7, nothing, 3) == (7, 0, 3)
+  @test DataSplits._resolve_sizes(50, 35, nothing, 15) == (35, 0, 15)
+  @test DataSplits._resolve_sizes(50, 30, 10, 10) == (30, 10, 10)
+
+  # Rounding remainder absorbed by train (50% of 7 → train=4, test=3)
+  @test DataSplits._resolve_sizes(7, 50, nothing, 50) == (4, 0, 3)
+
+  # Each value must be ≥ 1
+  @test_throws SplitParameterError DataSplits._resolve_sizes(10, 0, nothing, 100)
+  @test_throws SplitParameterError DataSplits._resolve_sizes(10, 100, nothing, 0)
+  @test_throws SplitParameterError DataSplits._resolve_sizes(10, 70, 0, 30)
+
+  # Sum is neither 100 nor N
+  @test_throws SplitParameterError DataSplits._resolve_sizes(50, 30, nothing, 25)
+  @test_throws SplitParameterError DataSplits._resolve_sizes(40, 30, nothing, 30)
+
+  # Resolved n_train < 1 (1% of 10 = 0)
+  @test_throws SplitParameterError DataSplits._resolve_sizes(10, 1, nothing, 99)
 end

--- a/test/test-utils.jl
+++ b/test/test-utils.jl
@@ -1,6 +1,6 @@
 using Test
 using DataSplits: SplitParameterError
-import DataSplits
+import DataSplits: ValidFraction
 
 @testset "_resolve_sizes" begin
   # Percentages (sum to 100)


### PR DESCRIPTION
## Summary

Implements the API redesign discussed in [PR #16](https://github.com/davide-grheco/DataSplits.jl/pull/16#issuecomment-4334449240) (option B). Cohort sizes move off each strategy's `frac` field and onto `partition` itself as integer keywords (`train`, `validation`, `test`). The variadic form replaces `WithValidation` natively, so PR #16 can be closed in favour of this one.

```julia
# 2 cohorts, percentages
partition(X, KennardStoneSplit(); train = 80, test = 20)

# 2 cohorts, absolute counts (N = 250)
partition(X, RandomSplit(); train = 200, test = 50)

# 3 cohorts: first strategy splits off the test cohort,
# second splits validation from the remaining train pool
partition(X, RandomSplit(), KennardStoneSplit();
          train = 70, validation = 10, test = 20)
```

Bumps the package to **0.3.0** (breaking).

## Why

Per Davide's review on #16: per-strategy fractions force users to do the multiplicative arithmetic by hand to get a global 70:10:20 split. Putting the sizes on `partition` removes that friction and makes the variadic train/val/test path a one-liner with no combinator.

## Size semantics

All sizes are positive integers. Two interpretations are accepted, distinguished by the sum of the values:

- **Percentages** — values sum to `100`.
- **Absolute counts** — values sum to `N = numobs(data)`.

Any other sum is rejected with a clear error mentioning both modes. When percentages do not divide `N` exactly, `n_train` and `n_val` are rounded to the nearest integer and `n_test` absorbs the remainder so that `n_train + n_val + n_test == N`. This preserves the rounding behaviour of the previous `train_test_counts(N, frac)`.

The case `N == 100` is unambiguous (both interpretations yield the same counts). `:remaining` and integer-percentages-vs-counts heuristics were considered and explicitly excluded — the user is required to be exact.

## Internal contract

`_partition` no longer reads sizes from the strategy. Its contract is now:

```julia
_partition(data, alg; n_train, n_test, target, time, groups, rng, kwargs...) -> AbstractSplitResult
```

For the variadic 3-cohort form, `partition` mirrors the old `WithValidation` logic: applies the first strategy with `n_train + n_val` vs `n_test`, slices the train pool, applies the second strategy with `n_train` vs `n_val`, and remaps indices to global. Both inner calls must return a `TrainTestSplit`; otherwise `SplitNotImplementedError` is raised. Slot resolution (`_resolve_slot`) is unified to take a tuple of strategies so it works for one or two passes.

## Strategy changes

The `frac::ValidFraction` field is dropped from all 13 struct strategies. Constructors become parameter-only:

| Before | After |
| --- | --- |
| `RandomSplit(0.8)` | `RandomSplit()` |
| `KennardStoneSplit(0.8, Cityblock())` | `KennardStoneSplit(Cityblock())` |
| `SPXYSplit(0.7; metric_X=…)` | `SPXYSplit(; metric_X=…)` |
| `MoraisLimaMartinSplit(0.8; swap_frac=0.1)` | `MoraisLimaMartinSplit(; swap_frac=0.1)` |
| `OptiSimSplit(0.7; max_subsample_size=10)` | `OptiSimSplit(; max_subsample_size=10)` |
| `GroupShuffleSplit(0.8)` | `GroupShuffleSplit()` |
| `GroupStratifiedSplit(:proportional; frac=0.8)` | `GroupStratifiedSplit(:proportional)` |
| `TargetPropertyHigh(0.8)` | `TargetPropertyHigh()` |
| `TimeSplitOldest(0.8)` | `TimeSplitOldest()` |

`MoraisLimaMartinSplit.swap_frac` stays as a `Float64` field (it's a behavioural knob, not a partition size) with explicit `(0,1)` validation in the constructor. `ValidFraction` and `train_test_counts` are deleted; size validation lives entirely in `partition`'s parser.

## Folding / CV

Out of scope (issue #17). The sizes-on-`partition` design leaves room for a `FoldingOperation` subtype later that rejects size keywords (since fold counts are intrinsic), per Davide's note on #16.

## What's gone

- `ValidFraction` (struct + arithmetic ops)
- `train_test_counts(N, frac)`
- The `frac` positional argument from every strategy constructor

## Compatibility

Breaking. All call sites that pass a fraction to a strategy constructor need to migrate. The strategies themselves keep the same names, traits, and result types — only their construction and the `partition` signature changed.

## Pre-existing items not addressed here

- `ArrayInterface` is in `[deps]`/`[compat]` of `Project.toml` but is not imported anywhere any more. Worth a tiny follow-up PR.
- `using StatsBase: minmax` in `src/clustering/SphereExclusion.jl` is unused (the file uses `minimum`/`maximum` from Base).
- `docs/src/*.md` is still on the pre-`partition` API (issue #19).

## Relation to PR #16

Supersedes it. Once this lands, `feat/with-validation` can be closed without merging — the variadic `partition` produces a `TrainValTestSplit` natively, so the `WithValidation` combinator is no longer needed.