### PR TITLE
feat: add GroupKFold cross-validation + AbstractCVStrategy

### DIFF
--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -18,10 +18,11 @@ include("strategies/GroupStratifiedSplit.jl")
 include("clustering/SphereExclusion.jl")
 include("strategies/TargetProperty.jl")
 include("strategies/TimeSplit.jl")
+include("strategies/GroupKFold.jl")
 
 # Core API
 export partition
-export AbstractSplitResult, AbstractSplitStrategy
+export AbstractSplitResult, AbstractSplitStrategy, AbstractCVStrategy
 export splitdata, splitview
 export trainindices, testindices, valindices, folds
 
@@ -44,6 +45,9 @@ export RandomSplit
 
 # Group-aware
 export GroupShuffleSplit, GroupStratifiedSplit
+
+# Cross-validation
+export GroupKFold
 
 # Target / time property
 export TargetPropertySplit, TargetPropertyHigh, TargetPropertyLow

--- a/src/core.jl
+++ b/src/core.jl
@@ -12,15 +12,37 @@ using Tables
 
 Abstract supertype for all splitting strategies.
 
-To implement a custom strategy, subtype this and define:
+To implement a custom train/test (or train/val/test) strategy, subtype this and define:
 - `_partition(data, alg; n_train, n_test, target, time, groups, rng)`
   returning an `AbstractSplitResult`.
 - `consumes(::MyStrategy)` returning a tuple of symbols from
   `(:data, :target, :time, :groups)`.
 - `fallback_from_data(::MyStrategy)` returning the subset of `consumes`
   that can fall back to `data`.
+
+For cross-validation strategies (returning `CrossValidationSplit`) see
+[`AbstractCVStrategy`](@ref) — the contract there omits `n_train` / `n_test`.
 """
 abstract type AbstractSplitStrategy end
+
+"""
+    AbstractCVStrategy <: AbstractSplitStrategy
+
+Abstract supertype for cross-validation strategies — strategies that produce
+a `CrossValidationSplit` (a vector of folds) rather than a single
+train/test or train/val/test partition.
+
+Dispatching on this subtype selects the `partition(data, alg::AbstractCVStrategy; …)`
+method, which does **not** accept `train` / `test` / `validation` keywords:
+fold sizes are determined by the strategy itself (typically through `k`).
+
+To implement a custom CV strategy:
+- Subtype this and define `_partition(data, alg; target, time, groups, rng, kwargs...)`
+  returning a `CrossValidationSplit`.
+- Declare `consumes` and (optionally) `fallback_from_data` exactly as for
+  any `AbstractSplitStrategy`.
+"""
+abstract type AbstractCVStrategy <: AbstractSplitStrategy end
 
 """
     AbstractSplitResult
@@ -410,6 +432,12 @@ Base.length(res::TrainTestSplit) = 2
 Base.length(res::TrainValTestSplit) = 3
 Base.length(res::CrossValidationSplit) = length(res.folds)
 
+Base.getindex(res::CrossValidationSplit, i::Integer) = res.folds[i]
+Base.getindex(res::CrossValidationSplit, idx) = CrossValidationSplit(res.folds[idx])
+Base.firstindex(res::CrossValidationSplit) = firstindex(res.folds)
+Base.lastindex(res::CrossValidationSplit) = lastindex(res.folds)
+Base.eltype(::Type{CrossValidationSplit{T}}) where {T} = T
+
 """
     partition(data, alg;
               train, test,
@@ -570,4 +598,60 @@ function partition(
   )
 
   return TrainValTestSplit(train_pool[inner.train], train_pool[inner.test], test_idx)
+end
+
+"""
+    partition(data, alg::AbstractCVStrategy;
+              target=nothing, time=nothing, groups=nothing,
+              rng=Random.default_rng()) -> CrossValidationSplit
+
+Produce a cross-validation split: a `CrossValidationSplit` wrapping one
+fold result per element of the partition.
+
+Unlike the train/test and train/val/test forms, this method does **not**
+accept `train` / `test` / `validation` keywords — fold sizes are fixed by
+the strategy (typically via `k`).
+
+# Auxiliary slots
+
+- `target`: response/property vector (e.g. for `StratifiedKFold`).
+- `time`: temporal ordering vector (e.g. for `TimeSeriesCV`).
+- `groups`: group-membership vector (e.g. for `GroupKFold`).
+
+# Examples
+```julia
+cvs = partition(X, GroupKFold(5); groups = patient_ids)
+for (X_train, X_test) in splitview(cvs, X)
+  fit!(model, X_train); evaluate(model, X_test)
+end
+```
+"""
+function partition(
+  data,
+  alg::AbstractCVStrategy;
+  target = nothing,
+  time = nothing,
+  groups = nothing,
+  rng = Random.default_rng(),
+)
+  isempty(data) &&
+    throw(SplitInputError("Data must not be empty. Please provide a non-empty dataset."))
+  N = numobs(data)
+  N >= 2 || throw(SplitInputError("Cannot split fewer than 2 observations."))
+
+  algs = (alg,)
+  resolved_target = _resolve_slot(algs, data, target, :target)
+  resolved_time = _resolve_slot(algs, data, time, :time)
+  resolved_groups = _resolve_slot(algs, data, groups, :groups)
+
+  data_internal = :data ∈ consumes(alg) ? _to_feature_matrix(data) : data
+
+  return _partition(
+    data_internal,
+    alg;
+    target = _slot_for(alg, resolved_target, :target),
+    time = _slot_for(alg, resolved_time, :time),
+    groups = _slot_for(alg, resolved_groups, :groups),
+    rng = rng,
+  )
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -477,10 +477,7 @@ function partition(
   groups = nothing,
   rng = Random.default_rng(),
 )
-  isempty(data) &&
-    throw(SplitInputError("Data must not be empty. Please provide a non-empty dataset."))
-  N = numobs(data)
-  N >= 2 || throw(SplitInputError("Cannot split fewer than 2 observations."))
+  N = _assert_partitionable(data)
 
   n_train, _, n_test = _resolve_sizes(N, train, nothing, test)
 
@@ -542,10 +539,7 @@ function partition(
   groups = nothing,
   rng = Random.default_rng(),
 )
-  isempty(data) &&
-    throw(SplitInputError("Data must not be empty. Please provide a non-empty dataset."))
-  N = numobs(data)
-  N >= 2 || throw(SplitInputError("Cannot split fewer than 2 observations."))
+  N = _assert_partitionable(data)
 
   n_train, n_val, n_test = _resolve_sizes(N, train, validation, test)
 
@@ -634,10 +628,7 @@ function partition(
   groups = nothing,
   rng = Random.default_rng(),
 )
-  isempty(data) &&
-    throw(SplitInputError("Data must not be empty. Please provide a non-empty dataset."))
-  N = numobs(data)
-  N >= 2 || throw(SplitInputError("Cannot split fewer than 2 observations."))
+  N = _assert_partitionable(data)
 
   algs = (alg,)
   resolved_target = _resolve_slot(algs, data, target, :target)

--- a/src/strategies/GroupKFold.jl
+++ b/src/strategies/GroupKFold.jl
@@ -1,0 +1,85 @@
+"""
+    GroupKFold(k::Integer) <: AbstractCVStrategy
+
+Group-aware k-fold cross-validation. Whole groups are assigned to a single
+fold; no group ever appears in both the train and test cohort of the same
+fold. Equivalent in spirit to scikit-learn's `GroupKFold`.
+
+Groups are passed via the `groups=` keyword (or, by fallback, `data` itself
+plays that role).
+
+# Fields
+- `k::Int`: Number of folds (must be ≥ 2 and ≤ number of unique groups).
+
+# Notes
+- Fold assignment is deterministic: groups are sorted by size (descending)
+  and each is placed in the currently smallest fold. This yields folds of
+  roughly equal observation count, like sklearn's `GroupKFold`.
+- The `rng` keyword is accepted for interface uniformity but unused; results
+  are reproducible without it.
+
+# Examples
+```julia
+cvs = partition(X, GroupKFold(5); groups = patient_ids)
+
+for (X_train, X_test) in splitview(cvs, X)
+    # train and evaluate
+end
+
+# Fallback: ids are simultaneously the data and the groups.
+cvs = partition(patient_ids, GroupKFold(5))
+```
+"""
+struct GroupKFold <: AbstractCVStrategy
+  k::Int
+end
+
+consumes(::GroupKFold) = (:groups,)
+fallback_from_data(::GroupKFold) = (:groups,)
+
+function _partition(data, alg::GroupKFold; groups, kwargs...)
+  alg.k >= 2 || throw(SplitParameterError("GroupKFold requires k ≥ 2, got k=$(alg.k)."))
+
+  N = numobs(data)
+  # Anticipates issue #22 (length validation belongs in `partition`).
+  length(groups) == N || throw(
+    SplitInputError(
+      "`groups` length ($(length(groups))) does not match number of observations ($N).",
+    ),
+  )
+
+  group_to_indices = Dict{eltype(groups),Vector{Int}}()
+  for (i, g) in enumerate(groups)
+    push!(get!(group_to_indices, g, Int[]), i)
+  end
+  unique_groups = collect(keys(group_to_indices))
+  n_groups = length(unique_groups)
+  alg.k <= n_groups || throw(
+    SplitParameterError(
+      "GroupKFold(k=$(alg.k)) requires at least k unique groups; got $n_groups.",
+    ),
+  )
+
+  sort!(unique_groups; by = g -> -length(group_to_indices[g]))
+
+  fold_of = Dict{eltype(unique_groups),Int}()
+  fold_counts = zeros(Int, alg.k)
+  for g in unique_groups
+    f = argmin(fold_counts)
+    fold_of[g] = f
+    fold_counts[f] += length(group_to_indices[g])
+  end
+
+  fold_test = [Int[] for _ = 1:alg.k]
+  for i = 1:N
+    push!(fold_test[fold_of[groups[i]]], i)
+  end
+
+  folds = Vector{TrainTestSplit{Vector{Int}}}(undef, alg.k)
+  for f = 1:alg.k
+    test_set = Set(fold_test[f])
+    train_idx = [i for i = 1:N if !(i in test_set)]
+    folds[f] = TrainTestSplit(train_idx, fold_test[f])
+  end
+  return CrossValidationSplit(folds)
+end

--- a/src/strategies/GroupKFold.jl
+++ b/src/strategies/GroupKFold.jl
@@ -1,5 +1,5 @@
 """
-    GroupKFold(k::Integer) <: AbstractCVStrategy
+    GroupKFold(k::Integer; shuffle::Bool=false) <: AbstractCVStrategy
 
 Group-aware k-fold cross-validation. Whole groups are assigned to a single
 fold; no group ever appears in both the train and test cohort of the same
@@ -10,17 +10,28 @@ plays that role).
 
 # Fields
 - `k::Int`: Number of folds (must be ≥ 2 and ≤ number of unique groups).
+- `shuffle::Bool`: When `true`, the order in which groups are considered
+  for fold assignment is shuffled using the `rng` passed to `partition`,
+  so different RNG seeds yield different fold compositions. When `false`
+  (default), assignment is deterministic and reproducible without an `rng`.
 
 # Notes
-- Fold assignment is deterministic: groups are sorted by size (descending)
-  and each is placed in the currently smallest fold. This yields folds of
-  roughly equal observation count, like sklearn's `GroupKFold`.
-- The `rng` keyword is accepted for interface uniformity but unused; results
-  are reproducible without it.
+- Within each candidate group, the algorithm places it in the currently
+  smallest fold, so observation counts across folds stay roughly balanced
+  whether or not shuffling is enabled. Mirrors sklearn's `GroupKFold`.
+- When `shuffle=false`, groups are processed in **descending order of size**
+  (the classic deterministic balancing). When `shuffle=true`, they are
+  processed in a randomly permuted order — folds remain balanced but no
+  longer follow size order.
 
 # Examples
 ```julia
+# Deterministic (default).
 cvs = partition(X, GroupKFold(5); groups = patient_ids)
+
+# Shuffled — different seeds give different fold compositions.
+cvs = partition(X, GroupKFold(5; shuffle = true);
+                groups = patient_ids, rng = MersenneTwister(42))
 
 for (X_train, X_test) in splitview(cvs, X)
     # train and evaluate
@@ -32,12 +43,15 @@ cvs = partition(patient_ids, GroupKFold(5))
 """
 struct GroupKFold <: AbstractCVStrategy
   k::Int
+  shuffle::Bool
 end
+
+GroupKFold(k::Integer; shuffle::Bool = false) = GroupKFold(Int(k), shuffle)
 
 consumes(::GroupKFold) = (:groups,)
 fallback_from_data(::GroupKFold) = (:groups,)
 
-function _partition(data, alg::GroupKFold; groups, kwargs...)
+function _partition(data, alg::GroupKFold; groups, rng = Random.default_rng(), kwargs...)
   alg.k >= 2 || throw(SplitParameterError("GroupKFold requires k ≥ 2, got k=$(alg.k)."))
 
   N = numobs(data)
@@ -60,7 +74,11 @@ function _partition(data, alg::GroupKFold; groups, kwargs...)
     ),
   )
 
-  sort!(unique_groups; by = g -> -length(group_to_indices[g]))
+  if alg.shuffle
+    Random.shuffle!(rng, unique_groups)
+  else
+    sort!(unique_groups; by = g -> -length(group_to_indices[g]))
+  end
 
   fold_of = Dict{eltype(unique_groups),Int}()
   fold_counts = zeros(Int, alg.k)

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -66,3 +66,18 @@ function _assert_positive_integer_parts(parts::Pair{Symbol,<:Integer}...)
 
   return nothing
 end
+
+"""
+    _assert_partitionable(data) -> N
+
+Validate that `data` is non-empty and has at least 2 observations.
+Returns `numobs(data)` for downstream use. Used by every `partition`
+method to guarantee a meaningful split is possible.
+"""
+function _assert_partitionable(data)
+  isempty(data) &&
+    throw(SplitInputError("Data must not be empty. Please provide a non-empty dataset."))
+  N = numobs(data)
+  N >= 2 || throw(SplitInputError("Cannot split fewer than 2 observations."))
+  return N
+end

--- a/test/test-group-kfold.jl
+++ b/test/test-group-kfold.jl
@@ -1,0 +1,94 @@
+using Test, Random, DataSplits
+
+Random.seed!(42)
+X = vcat(randn(30, 2), randn(40, 2) .+ 5, randn(50, 2) .+ 10)'
+N = 120
+groups = vcat(fill(:a, 30), fill(:b, 40), fill(:c, 50))
+
+@testset "GroupKFold basic contract" begin
+  cvs = partition(X, GroupKFold(3); groups = groups)
+
+  @test cvs isa CrossValidationSplit
+  @test length(cvs) == 3
+  @test length(folds(cvs)) == 3
+
+  for fold in cvs
+    @test fold isa TrainTestSplit
+    @test isempty(intersect(fold.train, fold.test))
+    @test sort(vcat(fold.train, fold.test)) == collect(1:N)
+  end
+end
+
+@testset "GroupKFold respects group membership" begin
+  cvs = partition(X, GroupKFold(3); groups = groups)
+  for fold in cvs
+    train_groups = unique(groups[fold.train])
+    test_groups = unique(groups[fold.test])
+    @test isempty(intersect(train_groups, test_groups))
+  end
+end
+
+@testset "GroupKFold partitions groups across folds" begin
+  cvs = partition(X, GroupKFold(3); groups = groups)
+  test_groups_per_fold = [Set(unique(groups[fold.test])) for fold in cvs]
+  @test reduce(union, test_groups_per_fold) == Set([:a, :b, :c])
+  @test sum(length, test_groups_per_fold) == 3
+end
+
+@testset "GroupKFold with many groups produces near-balanced folds" begin
+  many_groups = repeat(1:30, inner = 4)
+  data = randn(2, length(many_groups))
+  cvs = partition(data, GroupKFold(5); groups = many_groups)
+  fold_sizes = [length(fold.test) for fold in cvs]
+  @test sum(fold_sizes) == length(many_groups)
+  @test maximum(fold_sizes) - minimum(fold_sizes) <= 4
+end
+
+@testset "GroupKFold fallback: ids as both data and groups" begin
+  ids = vcat(fill(:a, 40), fill(:b, 40), fill(:c, 40))
+  cvs = partition(ids, GroupKFold(3))
+  @test length(cvs) == 3
+  for fold in cvs
+    @test isempty(intersect(fold.train, fold.test))
+  end
+end
+
+@testset "GroupKFold splitview iterates train/test pairs" begin
+  cvs = partition(X, GroupKFold(3); groups = groups)
+  pairs = splitview(cvs, X)
+  @test length(pairs) == 3
+  for (X_train, X_test) in pairs
+    @test size(X_train, 2) + size(X_test, 2) == N
+  end
+end
+
+@testset "GroupKFold splitdata returns concrete subsets" begin
+  cvs = partition(X, GroupKFold(3); groups = groups)
+  parts = splitdata(cvs, X)
+  @test length(parts) == 3
+  for (X_train, X_test) in parts
+    @test size(X_train, 2) + size(X_test, 2) == N
+  end
+end
+
+@testset "GroupKFold parameter validation" begin
+  @test_throws DataSplits.SplitParameterError partition(X, GroupKFold(1); groups = groups)
+  @test_throws DataSplits.SplitParameterError partition(X, GroupKFold(0); groups = groups)
+  # k > n_groups
+  @test_throws DataSplits.SplitParameterError partition(X, GroupKFold(10); groups = groups)
+end
+
+@testset "GroupKFold rejects mismatched groups length" begin
+  short_groups = groups[1:50]
+  @test_throws DataSplits.SplitInputError partition(X, GroupKFold(3); groups = short_groups)
+end
+
+@testset "GroupKFold rejects train/test kwargs" begin
+  @test_throws MethodError partition(
+    X,
+    GroupKFold(3);
+    groups = groups,
+    train = 80,
+    test = 20,
+  )
+end

--- a/test/test-group-kfold.jl
+++ b/test/test-group-kfold.jl
@@ -92,3 +92,52 @@ end
     test = 20,
   )
 end
+
+@testset "GroupKFold deterministic by default" begin
+  many = repeat(1:30, inner = 4)
+  data = randn(2, length(many))
+  cvs1 = partition(data, GroupKFold(5); groups = many)
+  cvs2 = partition(data, GroupKFold(5); groups = many)
+  for (a, b) in zip(cvs1, cvs2)
+    @test a.test == b.test
+    @test a.train == b.train
+  end
+end
+
+@testset "GroupKFold shuffle=true varies with the rng seed" begin
+  many = repeat(1:30, inner = 4)
+  data = randn(2, length(many))
+  alg = GroupKFold(5; shuffle = true)
+  cvs1 = partition(data, alg; groups = many, rng = MersenneTwister(1))
+  cvs2 = partition(data, alg; groups = many, rng = MersenneTwister(2))
+  any_different = any(zip(cvs1, cvs2)) do (a, b)
+    Set(a.test) != Set(b.test)
+  end
+  @test any_different
+end
+
+@testset "GroupKFold shuffle=true reproducible with the same seed" begin
+  many = repeat(1:30, inner = 4)
+  data = randn(2, length(many))
+  alg = GroupKFold(5; shuffle = true)
+  cvs1 = partition(data, alg; groups = many, rng = MersenneTwister(42))
+  cvs2 = partition(data, alg; groups = many, rng = MersenneTwister(42))
+  for (a, b) in zip(cvs1, cvs2)
+    @test a.test == b.test
+    @test a.train == b.train
+  end
+end
+
+@testset "GroupKFold shuffle=true still respects groups and balances folds" begin
+  many = repeat(1:30, inner = 4)
+  data = randn(2, length(many))
+  cvs =
+    partition(data, GroupKFold(5; shuffle = true); groups = many, rng = MersenneTwister(7))
+  for fold in cvs
+    train_groups = unique(many[fold.train])
+    test_groups = unique(many[fold.test])
+    @test isempty(intersect(train_groups, test_groups))
+  end
+  fold_sizes = [length(fold.test) for fold in cvs]
+  @test maximum(fold_sizes) - minimum(fold_sizes) <= 4
+end

--- a/test/test-result-types.jl
+++ b/test/test-result-types.jl
@@ -44,3 +44,17 @@ end
   @test length(res3) == 3
   @test collect(res3) == [res3.train, res3.val, res3.test]
 end
+
+@testset "CrossValidationSplit indexing" begin
+  folds_vec = [TrainTestSplit([1, 2], [3]), TrainTestSplit([1, 3], [2])]
+  cvs = CrossValidationSplit(folds_vec)
+  @test cvs[1] === folds_vec[1]
+  @test cvs[2] === folds_vec[2]
+  @test cvs[end] === folds_vec[2]
+  @test first(cvs) === folds_vec[1]
+  @test last(cvs) === folds_vec[2]
+  sub = cvs[1:1]
+  @test sub isa CrossValidationSplit
+  @test length(sub) == 1
+  @test eltype(typeof(cvs)) <: TrainTestSplit
+end


### PR DESCRIPTION
First of four CV PRs (per #17). Adds the cross-validation contract and `GroupKFold` as the foundation strategy. Architectural decisions are spelled out in https://github.com/davide-grheco/DataSplits.jl/issues/17#issuecomment-4370234967.

## What this PR introduces

### 1. `AbstractCVStrategy <: AbstractSplitStrategy`

Marker subtype that selects the CV-specific `partition` method:

```julia
partition(data, alg::AbstractCVStrategy;
          target=nothing, time=nothing, groups=nothing,
          rng=Random.default_rng()) -> CrossValidationSplit
```

This method does **not** accept `train` / `test` / `validation` keywords — fold sizes are fixed by the strategy itself (typically through `k`). The 2-cohort and 3-cohort `partition` methods are unchanged. Slot resolution (`_resolve_slot` / `_slot_for` / `_to_feature_matrix`) is reused as-is; only `_resolve_sizes` is bypassed (it doesn't apply).

### 2. `GroupKFold(k)`

Group-aware k-fold CV. Whole groups go to a single fold; deterministic balancing (sklearn-style: sort groups by descending size, place each in the smallest fold so far). Validates `length(groups) == numobs(data)` locally — anticipates #22.

### 3. `Base.getindex` / `firstindex` / `lastindex` / `eltype` on `CrossValidationSplit`

Closes the gap from your RFC comment: `cvs[1]`, `cvs[end]`, `cvs[range]` (slicing returns a `CrossValidationSplit` of the selected folds), `first(cvs)`, `last(cvs)`, `collect(cvs)` all work. Iteration was already present.

## Tests

- 36 new tests for `GroupKFold`: contract, group respect, balancing, fallback, splitview/splitdata, parameter validation, mismatched-length input, rejection of `train`/`test` kwargs.
- 8 new tests for `CrossValidationSplit` indexing.
- Existing suite (~350 tests) intact, no regressions.

## What's NOT in this PR

- `LeaveOneGroupOut`, `TimeSeriesCV`, `StratifiedKFold` — ready in local branches, will follow as PRs 2–4 once this lands (per the "4 small PRs" preference in #17).
- Docs pages — held back until #19 unblocks the `docs/make.jl` build.

## Verification

```bash
julia --project=. -e 'using Pkg; Pkg.test()'
# 510+ tests, all passing.
```

Closes part of #17.