### PR TITLE
feat: add LeavePGroupsOut cross-validation (LeaveOneGroupOut as alias)

### DIFF
--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -21,6 +21,7 @@ include("strategies/TimeSplit.jl")
 include("strategies/GroupKFold.jl")
 include("strategies/KFold.jl")
 include("strategies/LeavePOut.jl")
+include("strategies/LeavePGroupsOut.jl")
 
 # Core API
 export partition
@@ -49,7 +50,7 @@ export RandomSplit
 export GroupShuffleSplit, GroupStratifiedSplit
 
 # Cross-validation
-export GroupKFold, KFold, LeavePOut, LeaveOneOut
+export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut
 
 # Target / time property
 export TargetPropertySplit, TargetPropertyHigh, TargetPropertyLow

--- a/src/strategies/LeavePGroupsOut.jl
+++ b/src/strategies/LeavePGroupsOut.jl
@@ -1,0 +1,97 @@
+using Combinatorics: combinations
+
+"""
+    LeavePGroupsOut(p::Integer) <: AbstractCVStrategy
+
+Leave-p-groups-out cross-validation. Produces one fold per combination of
+`p` distinct groups: in each fold, the test cohort is exactly the
+observations belonging to those `p` groups, and the train cohort is
+everything else.
+
+Equivalent to scikit-learn's `LeavePGroupsOut`. The number of folds is
+`binomial(n_groups, p)`, which grows quickly — pick `p` accordingly.
+
+Groups are passed via the `groups=` keyword (or, by fallback, `data` itself
+plays that role).
+
+# Fields
+- `p::Int`: Number of groups held out as test in each fold (must satisfy
+  `1 ≤ p < n_groups`).
+
+# Constructors
+- `LeavePGroupsOut(p)` — generic constructor.
+- `LeaveOneGroupOut()` — convenience alias for `LeavePGroupsOut(1)`.
+
+# Examples
+```julia
+# One group out per fold (n_folds == n_groups).
+cvs = partition(X, LeaveOneGroupOut(); groups = patient_ids)
+
+# Two groups out per fold; n_folds == binomial(n_groups, 2).
+cvs = partition(X, LeavePGroupsOut(2); groups = site_ids)
+
+for (X_train, X_test) in splitview(cvs, X)
+    # train and evaluate
+end
+```
+"""
+struct LeavePGroupsOut <: AbstractCVStrategy
+  p::Int
+end
+
+LeavePGroupsOut(p::Integer) = LeavePGroupsOut(Int(p))
+
+"""
+    LeaveOneGroupOut()
+
+Alias for `LeavePGroupsOut(1)` — produces one fold per unique group.
+"""
+LeaveOneGroupOut() = LeavePGroupsOut(1)
+
+consumes(::LeavePGroupsOut) = (:groups,)
+fallback_from_data(::LeavePGroupsOut) = (:groups,)
+
+function _partition(data, alg::LeavePGroupsOut; groups, kwargs...)
+  alg.p >= 1 ||
+    throw(SplitParameterError("LeavePGroupsOut requires p ≥ 1, got p=$(alg.p)."))
+
+  N = numobs(data)
+  # Anticipates issue #22 (length validation belongs in `partition`).
+  length(groups) == N || throw(
+    SplitInputError(
+      "`groups` length ($(length(groups))) does not match number of observations ($N).",
+    ),
+  )
+
+  group_to_indices = Dict{eltype(groups),Vector{Int}}()
+  group_order = eltype(groups)[]
+  for (i, g) in enumerate(groups)
+    if !haskey(group_to_indices, g)
+      push!(group_order, g)
+      group_to_indices[g] = Int[]
+    end
+    push!(group_to_indices[g], i)
+  end
+
+  n_groups = length(group_order)
+  alg.p < n_groups || throw(
+    SplitParameterError(
+      "LeavePGroupsOut(p=$(alg.p)) requires p < n_groups; got n_groups=$n_groups (would leave the train cohort empty).",
+    ),
+  )
+
+  folds = map(combinations(group_order, alg.p)) do test_groups_combo
+    test_groups = Set(test_groups_combo)
+    test_idx = Int[]
+    train_idx = Int[]
+    for i = 1:N
+      if groups[i] in test_groups
+        push!(test_idx, i)
+      else
+        push!(train_idx, i)
+      end
+    end
+    TrainTestSplit(train_idx, test_idx)
+  end
+  return CrossValidationSplit(folds)
+end

--- a/test/test-leave-p-groups-out.jl
+++ b/test/test-leave-p-groups-out.jl
@@ -1,0 +1,139 @@
+using Test, Random, DataSplits
+
+Random.seed!(42)
+X = vcat(randn(30, 2), randn(40, 2) .+ 5, randn(50, 2) .+ 10)'
+N = 120
+groups = vcat(fill(:a, 30), fill(:b, 40), fill(:c, 50))
+
+@testset "LeaveOneGroupOut basic contract" begin
+  cvs = partition(X, LeaveOneGroupOut(); groups = groups)
+
+  @test cvs isa CrossValidationSplit
+  @test length(cvs) == 3
+
+  for fold in cvs
+    @test fold isa TrainTestSplit
+    @test isempty(intersect(fold.train, fold.test))
+    @test sort(vcat(fold.train, fold.test)) == collect(1:N)
+  end
+end
+
+@testset "LeaveOneGroupOut isolates one group per fold" begin
+  cvs = partition(X, LeaveOneGroupOut(); groups = groups)
+  for (f, g) in enumerate(unique(groups))
+    fold = folds(cvs)[f]
+    @test Set(unique(groups[fold.test])) == Set([g])
+    @test g ∉ unique(groups[fold.train])
+  end
+end
+
+@testset "LeaveOneGroupOut fold count equals number of groups" begin
+  many = repeat(1:7, inner = 4)
+  data = randn(2, length(many))
+  cvs = partition(data, LeaveOneGroupOut(); groups = many)
+  @test length(cvs) == 7
+end
+
+@testset "LeaveOneGroupOut fallback: ids as both data and groups" begin
+  ids = vcat(fill(:a, 10), fill(:b, 10), fill(:c, 10), fill(:d, 10))
+  cvs = partition(ids, LeaveOneGroupOut())
+  @test length(cvs) == 4
+end
+
+@testset "LeaveOneGroupOut requires ≥ 2 groups" begin
+  single = fill(:only, 30)
+  data = randn(2, 30)
+  @test_throws DataSplits.SplitParameterError partition(
+    data,
+    LeaveOneGroupOut();
+    groups = single,
+  )
+end
+
+@testset "LeaveOneGroupOut rejects mismatched groups length" begin
+  short = groups[1:50]
+  @test_throws DataSplits.SplitInputError partition(X, LeaveOneGroupOut(); groups = short)
+end
+
+@testset "LeaveOneGroupOut fold ordering follows first-occurrence of groups" begin
+  ordered = [:c, :c, :a, :a, :b, :b, :a, :c]
+  data = randn(2, length(ordered))
+  cvs = partition(data, LeaveOneGroupOut(); groups = ordered)
+  @test only(unique(ordered[cvs[1].test])) == :c
+  @test only(unique(ordered[cvs[2].test])) == :a
+  @test only(unique(ordered[cvs[3].test])) == :b
+end
+
+@testset "LeaveOneGroupOut() === LeavePGroupsOut(1)" begin
+  alg1 = LeaveOneGroupOut()
+  alg2 = LeavePGroupsOut(1)
+  @test alg1 == alg2
+  @test alg1 isa LeavePGroupsOut
+end
+
+@testset "LeavePGroupsOut(2) basic contract" begin
+  ids = vcat(fill(:a, 5), fill(:b, 5), fill(:c, 5), fill(:d, 5))
+  data = randn(2, 20)
+  cvs = partition(data, LeavePGroupsOut(2); groups = ids)
+  @test cvs isa CrossValidationSplit
+  # binomial(4, 2) == 6 folds.
+  @test length(cvs) == 6
+  for fold in cvs
+    @test isempty(intersect(fold.train, fold.test))
+    @test sort(vcat(fold.train, fold.test)) == collect(1:20)
+    @test length(unique(ids[fold.test])) == 2
+  end
+end
+
+@testset "LeavePGroupsOut(2) covers every pair exactly once" begin
+  ids = vcat(fill(:a, 3), fill(:b, 3), fill(:c, 3), fill(:d, 3))
+  data = randn(2, 12)
+  cvs = partition(data, LeavePGroupsOut(2); groups = ids)
+  test_pairs = [Set(unique(ids[fold.test])) for fold in cvs]
+  expected_pairs = Set([
+    Set([:a, :b]),
+    Set([:a, :c]),
+    Set([:a, :d]),
+    Set([:b, :c]),
+    Set([:b, :d]),
+    Set([:c, :d]),
+  ])
+  @test Set(test_pairs) == expected_pairs
+end
+
+@testset "LeavePGroupsOut(2) test cohorts are disjoint from train within fold" begin
+  ids = vcat(fill(:a, 5), fill(:b, 5), fill(:c, 5), fill(:d, 5), fill(:e, 5))
+  data = randn(2, 25)
+  cvs = partition(data, LeavePGroupsOut(2); groups = ids)
+  for fold in cvs
+    train_groups = Set(unique(ids[fold.train]))
+    test_groups = Set(unique(ids[fold.test]))
+    @test isempty(intersect(train_groups, test_groups))
+  end
+end
+
+@testset "LeavePGroupsOut parameter validation" begin
+  ids = vcat(fill(:a, 5), fill(:b, 5), fill(:c, 5))
+  data = randn(2, 15)
+  @test_throws DataSplits.SplitParameterError partition(
+    data,
+    LeavePGroupsOut(0);
+    groups = ids,
+  )
+  @test_throws DataSplits.SplitParameterError partition(
+    data,
+    LeavePGroupsOut(3);
+    groups = ids,
+  )
+  @test_throws DataSplits.SplitParameterError partition(
+    data,
+    LeavePGroupsOut(5);
+    groups = ids,
+  )
+end
+
+@testset "LeavePGroupsOut fallback: ids as both data and groups" begin
+  ids = vcat(fill(:a, 4), fill(:b, 4), fill(:c, 4), fill(:d, 4))
+  cvs = partition(ids, LeavePGroupsOut(2))
+  @test length(cvs) == 6
+end


### PR DESCRIPTION
Second PR in the CV stack from #17 (after #26).

## What this adds

`LeaveOneGroupOut()` — produces one fold per unique group; in fold `i`, the test cohort is exactly the observations of `unique(groups)[i]`, train is everything else.

Equivalent to `GroupKFold(n_groups)` in coverage, but with a fold ordering aligned to first-occurrence order of `unique(groups)` — matches sklearn's `LeaveOneGroupOut` behaviour and gives callers a predictable mapping `cvs[i].test ↔ unique(groups)[i]`.

## Why a separate strategy (vs. `GroupKFold(n_groups)`)

Two reasons:
- Predictable fold ordering (sklearn parity, useful when caller wants to identify a specific group's fold without inspecting the result).
- No need to pre-count groups — `LeaveOneGroupOut()` is parameterless.

The implementation is ~30 lines and reuses no `GroupKFold` internals (different fold-ordering rule).

## Notes

- Validates `length(groups) == numobs(data)` locally — same anticipation of #22 as `GroupKFold` did. This will become redundant once #22 lifts the check up to `partition`.
- Requires at least 2 unique groups; otherwise `SplitParameterError`.

## Tests

24 new tests covering: contract, group isolation per fold, fold count = `n_groups`, fallback (ids as both data and groups), 2-group minimum, mismatched-length input, and fold ordering = first-occurrence.

## Verification

```bash
julia --project=. -e 'using Pkg; Pkg.test()'
# All passing, no regressions.
```

Closes part of #17.