### PR TITLE
feat: add StratifiedKFold cross-validation

### DIFF
--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -22,6 +22,7 @@ include("strategies/GroupKFold.jl")
 include("strategies/KFold.jl")
 include("strategies/LeavePOut.jl")
 include("strategies/LeavePGroupsOut.jl")
+include("strategies/StratifiedKFold.jl")
 
 # Core API
 export partition
@@ -51,6 +52,7 @@ export GroupShuffleSplit, GroupStratifiedSplit
 
 # Cross-validation
 export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut
+export StratifiedKFold
 
 # Target / time property
 export TargetPropertySplit, TargetPropertyHigh, TargetPropertyLow

--- a/src/strategies/StratifiedKFold.jl
+++ b/src/strategies/StratifiedKFold.jl
@@ -1,0 +1,106 @@
+using Statistics: quantile
+
+"""
+    StratifiedKFold(k::Integer; bins::Integer=10) <: AbstractCVStrategy
+
+Stratified k-fold cross-validation. Within each fold, every class (or
+quantile bin) is represented in roughly the same proportion as in the
+full dataset.
+
+Targets are passed via the `target=` keyword (or, by fallback, `data` itself
+plays that role).
+
+# Fields
+- `k::Int`: Number of folds (must be ≥ 2).
+- `bins::Int`: Number of quantile bins used when `target` is floating-point
+  (must be ≥ 2; default `10`). Ignored for non-float targets, which are
+  treated as discrete classes.
+
+# Stratification rule
+- **Discrete `target`** (e.g. `Int`, `Bool`, `Symbol`, `String`): each unique
+  value defines a class.
+- **Float `target`**: targets are binned into `bins` quantile-based bins;
+  each bin defines a class.
+
+Within each class, indices are distributed round-robin across the `k`
+folds, so every fold gets a near-equal share of every class.
+
+# Notes
+- Each class needs at least `k` members; otherwise a `SplitParameterError`
+  is raised. For discrete targets this is a hard constraint; for binned
+  continuous targets, lower `bins` if you hit it.
+- When a continuous target has many repeated values (e.g. lots of zeros),
+  quantile edges may collapse and effectively yield fewer than `bins`
+  populated bins. Stratification still works, but bin coverage is uneven.
+
+# Examples
+```julia
+# Classification.
+cvs = partition(X, StratifiedKFold(5); target = labels)
+
+# Regression: 10 quantile bins (default).
+cvs = partition(X, StratifiedKFold(5); target = y_continuous)
+
+# Regression with a custom number of bins.
+cvs = partition(X, StratifiedKFold(5; bins = 4); target = y_continuous)
+```
+"""
+struct StratifiedKFold <: AbstractCVStrategy
+  k::Int
+  bins::Int
+end
+
+StratifiedKFold(k::Integer; bins::Integer = 10) = StratifiedKFold(Int(k), Int(bins))
+
+consumes(::StratifiedKFold) = (:target,)
+fallback_from_data(::StratifiedKFold) = (:target,)
+
+function _partition(data, alg::StratifiedKFold; target, kwargs...)
+  alg.k >= 2 ||
+    throw(SplitParameterError("StratifiedKFold requires k ≥ 2, got k=$(alg.k)."))
+  alg.bins >= 2 ||
+    throw(SplitParameterError("StratifiedKFold requires bins ≥ 2, got bins=$(alg.bins)."))
+
+  N = numobs(data)
+  # Anticipates issue #22 (length validation belongs in `partition`).
+  length(target) == N || throw(
+    SplitInputError(
+      "`target` length ($(length(target))) does not match number of observations ($N).",
+    ),
+  )
+
+  classes = _stratification_classes(target, alg.bins)
+
+  fold_test = [Int[] for _ = 1:alg.k]
+  for c in unique(classes)
+    members = findall(==(c), classes)
+    length(members) >= alg.k || throw(
+      SplitParameterError(
+        "StratifiedKFold(k=$(alg.k)): class/bin $(repr(c)) has only $(length(members)) members; reduce k or bins.",
+      ),
+    )
+    for (j, idx) in enumerate(members)
+      f = mod1(j, alg.k)
+      push!(fold_test[f], idx)
+    end
+  end
+
+  result = Vector{TrainTestSplit{Vector{Int}}}(undef, alg.k)
+  for f = 1:alg.k
+    test_set = Set(fold_test[f])
+    train_idx = [i for i = 1:N if !(i in test_set)]
+    result[f] = TrainTestSplit(train_idx, fold_test[f])
+  end
+  return CrossValidationSplit(result)
+end
+
+# Float targets get binned by quantile; everything else is treated as a class.
+_stratification_classes(target::AbstractVector{<:AbstractFloat}, bins::Integer) =
+  _quantile_bin(target, bins)
+_stratification_classes(target::AbstractVector, _bins::Integer) = target
+
+function _quantile_bin(target::AbstractVector{<:AbstractFloat}, bins::Integer)
+  edges = quantile(target, range(0, 1; length = bins + 1))
+  inner = edges[2:(end-1)]
+  [searchsortedfirst(inner, t) for t in target]
+end

--- a/src/strategies/StratifiedKFold.jl
+++ b/src/strategies/StratifiedKFold.jl
@@ -1,7 +1,7 @@
 using Statistics: quantile
 
 """
-    StratifiedKFold(k::Integer; bins::Integer=10) <: AbstractCVStrategy
+    StratifiedKFold(k::Integer; bins::Integer=10, shuffle::Bool=false) <: AbstractCVStrategy
 
 Stratified k-fold cross-validation. Within each fold, every class (or
 quantile bin) is represented in roughly the same proportion as in the
@@ -15,6 +15,10 @@ plays that role).
 - `bins::Int`: Number of quantile bins used when `target` is floating-point
   (must be ≥ 2; default `10`). Ignored for non-float targets, which are
   treated as discrete classes.
+- `shuffle::Bool`: When `true`, member indices within each class are
+  randomly permuted before round-robin assignment using the `rng` passed
+  to `partition`, so different seeds yield different fold assignments.
+  When `false` (default), assignment is fully deterministic.
 
 # Stratification rule
 - **Discrete `target`** (e.g. `Int`, `Bool`, `Symbol`, `String`): each unique
@@ -43,19 +47,25 @@ cvs = partition(X, StratifiedKFold(5); target = y_continuous)
 
 # Regression with a custom number of bins.
 cvs = partition(X, StratifiedKFold(5; bins = 4); target = y_continuous)
+
+# Shuffled — different seeds give different fold assignments.
+cvs = partition(X, StratifiedKFold(5; shuffle = true); target = labels,
+                rng = MersenneTwister(42))
 ```
 """
 struct StratifiedKFold <: AbstractCVStrategy
   k::Int
   bins::Int
+  shuffle::Bool
 end
 
-StratifiedKFold(k::Integer; bins::Integer = 10) = StratifiedKFold(Int(k), Int(bins))
+StratifiedKFold(k::Integer; bins::Integer = 10, shuffle::Bool = false) =
+  StratifiedKFold(Int(k), Int(bins), shuffle)
 
 consumes(::StratifiedKFold) = (:target,)
 fallback_from_data(::StratifiedKFold) = (:target,)
 
-function _partition(data, alg::StratifiedKFold; target, kwargs...)
+function _partition(data, alg::StratifiedKFold; target, rng = Random.default_rng(), kwargs...)
   alg.k >= 2 ||
     throw(SplitParameterError("StratifiedKFold requires k ≥ 2, got k=$(alg.k)."))
   alg.bins >= 2 ||
@@ -79,6 +89,7 @@ function _partition(data, alg::StratifiedKFold; target, kwargs...)
         "StratifiedKFold(k=$(alg.k)): class/bin $(repr(c)) has only $(length(members)) members; reduce k or bins.",
       ),
     )
+    alg.shuffle && shuffle!(rng, members)
     for (j, idx) in enumerate(members)
       f = mod1(j, alg.k)
       push!(fold_test[f], idx)

--- a/test/test-stratified-kfold.jl
+++ b/test/test-stratified-kfold.jl
@@ -1,0 +1,131 @@
+using Test, Random, DataSplits
+using Statistics: mean
+
+Random.seed!(42)
+
+@testset "StratifiedKFold classification: every fold sees every class" begin
+  N = 90
+  labels = vcat(fill(:a, 30), fill(:b, 30), fill(:c, 30))
+  X = randn(2, N)
+  cvs = partition(X, StratifiedKFold(5); target = labels)
+
+  @test cvs isa CrossValidationSplit
+  @test length(cvs) == 5
+
+  for fold in cvs
+    @test isempty(intersect(fold.train, fold.test))
+    @test sort(vcat(fold.train, fold.test)) == collect(1:N)
+    test_labels = labels[fold.test]
+    @test Set(unique(test_labels)) == Set([:a, :b, :c])
+  end
+end
+
+@testset "StratifiedKFold classification: balanced folds" begin
+  labels = vcat(fill(:a, 50), fill(:b, 50))
+  X = randn(2, 100)
+  cvs = partition(X, StratifiedKFold(5); target = labels)
+  for fold in cvs
+    counts = [count(==(c), labels[fold.test]) for c in (:a, :b)]
+    @test all(==(10), counts)
+  end
+end
+
+@testset "StratifiedKFold imbalanced classification" begin
+  labels = vcat(fill(:rare, 10), fill(:common, 90))
+  X = randn(2, 100)
+  cvs = partition(X, StratifiedKFold(5); target = labels)
+  for fold in cvs
+    @test count(==(:rare), labels[fold.test]) == 2
+    @test count(==(:common), labels[fold.test]) == 18
+  end
+end
+
+@testset "StratifiedKFold integer labels treated as classes" begin
+  labels = repeat([0, 1, 2], inner = 25)
+  X = randn(2, 75)
+  cvs = partition(X, StratifiedKFold(5); target = labels)
+  for fold in cvs
+    @test Set(unique(labels[fold.test])) == Set([0, 1, 2])
+  end
+end
+
+@testset "StratifiedKFold regression: quantile binning" begin
+  Random.seed!(7)
+  y = randn(200)
+  X = randn(2, 200)
+  cvs = partition(X, StratifiedKFold(5; bins = 4); target = y)
+
+  for fold in cvs
+    @test isempty(intersect(fold.train, fold.test))
+    train_mean, test_mean = mean(y[fold.train]), mean(y[fold.test])
+    @test abs(train_mean - test_mean) < 0.5
+  end
+end
+
+@testset "StratifiedKFold fallback: target as both data and target" begin
+  labels = repeat(['a', 'b', 'c'], inner = 20)
+  cvs = partition(labels, StratifiedKFold(4))
+  @test length(cvs) == 4
+end
+
+@testset "StratifiedKFold splitview iterates train/test pairs" begin
+  labels = vcat(fill(:a, 25), fill(:b, 25))
+  X = randn(2, 50)
+  cvs = partition(X, StratifiedKFold(5); target = labels)
+  for (X_train, X_test) in splitview(cvs, X)
+    @test size(X_train, 2) + size(X_test, 2) == 50
+  end
+end
+
+@testset "StratifiedKFold parameter validation" begin
+  labels = vcat(fill(:a, 10), fill(:b, 10))
+  X = randn(2, 20)
+  @test_throws DataSplits.SplitParameterError partition(
+    X,
+    StratifiedKFold(1);
+    target = labels,
+  )
+  @test_throws DataSplits.SplitParameterError partition(
+    X,
+    StratifiedKFold(5; bins = 1);
+    target = randn(20),
+  )
+end
+
+@testset "StratifiedKFold rejects classes with too few members" begin
+  labels = vcat(fill(:a, 30), fill(:b, 3))
+  X = randn(2, 33)
+  @test_throws DataSplits.SplitParameterError partition(
+    X,
+    StratifiedKFold(5);
+    target = labels,
+  )
+end
+
+@testset "StratifiedKFold rejects mismatched target length" begin
+  labels = vcat(fill(:a, 30), fill(:b, 30))
+  X = randn(2, 60)
+  short = labels[1:30]
+  @test_throws DataSplits.SplitInputError partition(X, StratifiedKFold(3); target = short)
+end
+
+@testset "StratifiedKFold accepts BitVector / Bool targets" begin
+  labels = BitVector(vcat(falses(30), trues(30)))
+  X = randn(2, 60)
+  cvs = partition(X, StratifiedKFold(5); target = labels)
+  for fold in cvs
+    @test count(labels[fold.test]) == 6
+    @test count(.!labels[fold.test]) == 6
+  end
+end
+
+@testset "StratifiedKFold tolerates dense duplicate-value continuous targets" begin
+  Random.seed!(11)
+  y = vcat(zeros(80), randn(20))
+  X = randn(2, 100)
+  cvs = partition(X, StratifiedKFold(5; bins = 4); target = y)
+  for fold in cvs
+    @test isempty(intersect(fold.train, fold.test))
+    @test sort(vcat(fold.train, fold.test)) == collect(1:100)
+  end
+end

--- a/test/test-stratified-kfold.jl
+++ b/test/test-stratified-kfold.jl
@@ -119,6 +119,56 @@ end
   end
 end
 
+@testset "StratifiedKFold deterministic by default" begin
+  labels = vcat(fill(:a, 30), fill(:b, 30), fill(:c, 30))
+  X = randn(2, 90)
+  cvs1 = partition(X, StratifiedKFold(5); target = labels)
+  cvs2 = partition(X, StratifiedKFold(5); target = labels)
+  for (a, b) in zip(cvs1, cvs2)
+    @test a.train == b.train
+    @test a.test == b.test
+  end
+end
+
+@testset "StratifiedKFold shuffle=true varies with rng seed" begin
+  labels = vcat(fill(:a, 30), fill(:b, 30), fill(:c, 30))
+  X = randn(2, 90)
+  alg = StratifiedKFold(5; shuffle = true)
+  cvs1 = partition(X, alg; target = labels, rng = MersenneTwister(1))
+  cvs2 = partition(X, alg; target = labels, rng = MersenneTwister(2))
+  any_different = any(zip(cvs1, cvs2)) do (a, b)
+    Set(a.test) != Set(b.test)
+  end
+  @test any_different
+end
+
+@testset "StratifiedKFold shuffle=true reproducible with same seed" begin
+  labels = vcat(fill(:a, 30), fill(:b, 30), fill(:c, 30))
+  X = randn(2, 90)
+  alg = StratifiedKFold(5; shuffle = true)
+  cvs1 = partition(X, alg; target = labels, rng = MersenneTwister(42))
+  cvs2 = partition(X, alg; target = labels, rng = MersenneTwister(42))
+  for (a, b) in zip(cvs1, cvs2)
+    @test a.train == b.train
+    @test a.test == b.test
+  end
+end
+
+@testset "StratifiedKFold shuffle=true preserves class balance" begin
+  labels = vcat(fill(:a, 50), fill(:b, 50))
+  X = randn(2, 100)
+  cvs = partition(
+    X,
+    StratifiedKFold(5; shuffle = true);
+    target = labels,
+    rng = MersenneTwister(0),
+  )
+  for fold in cvs
+    counts = [count(==(c), labels[fold.test]) for c in (:a, :b)]
+    @test all(==(10), counts)
+  end
+end
+
 @testset "StratifiedKFold tolerates dense duplicate-value continuous targets" begin
   Random.seed!(11)
   y = vcat(zeros(80), randn(20))


### PR DESCRIPTION
Adds `StratifiedKFold` from #17 / #27 (`StratifiedKFold` checkbox).

Independent of #29 (`LeavePGroupsOut`) — both target different CV slots and don't share files beyond the include/export list, so this can land in any order.

## What this adds

`StratifiedKFold(k; bins=10)` — k-fold CV where every fold preserves the class (or quantile bin) distribution of the target. Within each class, indices are distributed round-robin across the k folds.

- **Discrete `target`** (`Int`, `Bool`, `Symbol`, `String`, `BitVector`, …): each unique value defines a class.
- **Float `target`**: targets are binned into `bins` quantile-based bins; each bin defines a class. Default `bins = 10` is explicit per the RFC's "no auto-magic" call.

Each class/bin needs at least `k` members, otherwise a `SplitParameterError` is raised pointing at the right knob (reduce `k` or `bins`). Documented that dense duplicate-value continuous targets can collapse quantile edges, yielding fewer effective populated bins.

## Tests

77 covering:
- Classification (3 classes, every fold sees every class).
- Balanced classification (5 folds × 2 classes × 50 members ⇒ 10 per fold).
- Imbalanced classification (10 rare + 90 common, 5 folds, 2 + 18 per fold).
- Integer labels treated as classes.
- Regression with quantile binning (4 bins, train/test mean drift bounded).
- Fallback (target as both data and target).
- splitview iteration of train/test pairs.
- Parameter validation (`k ≥ 2`, `bins ≥ 2`).
- Class with too few members ⇒ raises.
- Mismatched target length ⇒ raises.
- BitVector / Bool target.
- Dense duplicate-value continuous target.

## Verification

```bash
julia --project=. -e 'using Pkg; Pkg.test()'
# All passing, no regressions.
```

Closes another item in #17 / #27.