### PR TITLE
fix: GroupStratifiedSplit Neyman allocation on non-matrix data

### DIFF
--- a/src/strategies/GroupStratifiedSplit.jl
+++ b/src/strategies/GroupStratifiedSplit.jl
@@ -48,6 +48,27 @@ GroupStratifiedSplit(allocation::Symbol; n = nothing) = GroupStratifiedSplit(all
 consumes(::GroupStratifiedSplit) = (:groups,)
 fallback_from_data(::GroupStratifiedSplit) = (:groups,)
 
+"""
+    _within_group_std(data, idxs) -> Float64
+
+Compute the average per-feature standard deviation of observations at
+`idxs` within `data`, container-agnostically. Used by `:neyman`
+allocation to weight groups by within-group dispersion.
+
+Tables.jl inputs are converted to an F×N matrix; Vectors are treated as
+1D feature streams. Singleton groups return `0.0` to avoid `NaN`.
+"""
+function _within_group_std(data, idxs)
+  sub = getobs(data, idxs)
+  mat = _to_feature_matrix(sub)
+  if mat isa AbstractVector
+    length(mat) <= 1 && return 0.0
+    return std(mat)
+  end
+  size(mat, 2) <= 1 && return 0.0
+  return mean(std(mat, dims = 2))
+end
+
 function _equal_allocation(cl_ids, idxs_by_cluster, n, rng)
   isnothing(n) &&
     throw(SplitParameterError("Parameter n must be provided for equal allocation."))
@@ -72,8 +93,7 @@ function _neyman_allocation(cl_ids, idxs_by_cluster, n, data, rng)
     throw(SplitParameterError("Parameter n must be provided for Neyman allocation."))
   stds = Dict{Any,Float64}()
   for cid in cl_ids
-    cluster_data = getobs(data, idxs_by_cluster[cid])
-    stds[cid] = mean(std(cluster_data, dims = 2))
+    stds[cid] = _within_group_std(data, idxs_by_cluster[cid])
   end
   numerators = Dict(cid => length(idxs_by_cluster[cid]) * stds[cid] for cid in cl_ids)
   denom = sum(values(numerators))

--- a/test/test-group-stratified-split.jl
+++ b/test/test-group-stratified-split.jl
@@ -45,4 +45,44 @@ import DataSplits: SplitInputError, SplitParameterError
     @test length(result.train) + length(result.test) == 15
     @test isempty(intersect(result.train, result.test))
   end
+
+  @testset "Neyman allocation on non-matrix data (issue #21)" begin
+    # Tables.jl input (NamedTuple of vectors): used to crash with
+    # `MethodError: no method matching std(::NamedTuple; dims=2)`.
+    nt = (a = randn(15), b = randn(15), c = randn(15), d = randn(15))
+    res = partition(
+      nt,
+      GroupStratifiedSplit(:neyman; n = 4);
+      groups = groups,
+      train = 50,
+      test = 50,
+    )
+    @test isempty(intersect(res.train, res.test))
+    @test length(res.train) + length(res.test) <= 15
+
+    # Vector input: used to crash with `InexactError: Int64(NaN)` because
+    # `std(::Vector; dims=2)` returned `NaN`.
+    v = randn(15)
+    res = partition(
+      v,
+      GroupStratifiedSplit(:neyman; n = 4);
+      groups = groups,
+      train = 50,
+      test = 50,
+    )
+    @test isempty(intersect(res.train, res.test))
+    @test length(res.train) + length(res.test) <= 15
+
+    # Singleton group: within-group std falls back to 0 instead of NaN.
+    groups_singleton = vcat(fill(1, 7), fill(2, 7), [3])
+    Xs = rand(4, 15)
+    res = partition(
+      Xs,
+      GroupStratifiedSplit(:neyman; n = 2);
+      groups = groups_singleton,
+      train = 50,
+      test = 50,
+    )
+    @test isempty(intersect(res.train, res.test))
+  end
 end


### PR DESCRIPTION
Closes #21.

## The bug

`GroupStratifiedSplit(:neyman; …)` crashed on any non-matrix input:

- **Tables.jl** (DataFrame, NamedTuple of vectors, …): `MethodError: no method matching std(::NamedTuple; dims=2)`.
- **Vector**: silently produced `NaN`, then blew up at `round(Int, NaN)` with `InexactError`.

Root cause: `_neyman_allocation` called `mean(std(getobs(data, idxs), dims = 2))`, which only makes sense for an F×N matrix.

## The fix

Extracted the per-group dispersion computation into a helper:

```julia
function _within_group_std(data, idxs)
  sub = getobs(data, idxs)
  mat = _to_feature_matrix(sub)
  if mat isa AbstractVector
    length(mat) <= 1 && return 0.0
    return std(mat)
  end
  size(mat, 2) <= 1 && return 0.0
  return mean(std(mat, dims = 2))
end
```

- Tables.jl inputs are normalised to an F×N matrix via the existing `_to_feature_matrix`.
- `AbstractVector` is treated as a 1D feature stream — plain `std`.
- Singleton groups short-circuit to `0.0` instead of leaking `NaN` into the proportional weighting.

## Tests

`test/test-group-stratified-split.jl` gains a "Neyman allocation on non-matrix data (issue #21)" testset covering:
- `NamedTuple` of vectors (Tables.jl path).
- Plain `Vector{Float64}`.
- Matrix with a singleton group (regression guard for the `NaN` short-circuit).

Suite green: 17/17 in `Group Stratified Split`, full test run passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
