### PR TITLE
chore: drop redundant per-strategy length checks

### DIFF
--- a/src/strategies/GroupKFold.jl
+++ b/src/strategies/GroupKFold.jl
@@ -55,12 +55,6 @@ function _partition(data, alg::GroupKFold; groups, rng = Random.default_rng(), k
   alg.k >= 2 || throw(SplitParameterError("GroupKFold requires k ≥ 2, got k=$(alg.k)."))
 
   N = numobs(data)
-  # Anticipates issue #22 (length validation belongs in `partition`).
-  length(groups) == N || throw(
-    SplitInputError(
-      "`groups` length ($(length(groups))) does not match number of observations ($N).",
-    ),
-  )
 
   group_to_indices = Dict{eltype(groups),Vector{Int}}()
   for (i, g) in enumerate(groups)

--- a/src/strategies/LeavePGroupsOut.jl
+++ b/src/strategies/LeavePGroupsOut.jl
@@ -56,12 +56,6 @@ function _partition(data, alg::LeavePGroupsOut; groups, kwargs...)
     throw(SplitParameterError("LeavePGroupsOut requires p ≥ 1, got p=$(alg.p)."))
 
   N = numobs(data)
-  # Anticipates issue #22 (length validation belongs in `partition`).
-  length(groups) == N || throw(
-    SplitInputError(
-      "`groups` length ($(length(groups))) does not match number of observations ($N).",
-    ),
-  )
 
   group_to_indices = Dict{eltype(groups),Vector{Int}}()
   group_order = eltype(groups)[]

--- a/src/strategies/StratifiedKFold.jl
+++ b/src/strategies/StratifiedKFold.jl
@@ -72,12 +72,6 @@ function _partition(data, alg::StratifiedKFold; target, rng = Random.default_rng
     throw(SplitParameterError("StratifiedKFold requires bins ≥ 2, got bins=$(alg.bins)."))
 
   N = numobs(data)
-  # Anticipates issue #22 (length validation belongs in `partition`).
-  length(target) == N || throw(
-    SplitInputError(
-      "`target` length ($(length(target))) does not match number of observations ($N).",
-    ),
-  )
 
   classes = _stratification_classes(target, alg.bins)
 


### PR DESCRIPTION
Now that #35 (centralised length validation in `_resolve_slot`) is merged, the per-strategy `length(slot) == numobs(data)` checks added in PRs #26 (`GroupKFold`), #29 (`LeavePGroupsOut`) and #33 (`StratifiedKFold`) are dead weight — the centralised check fires before `_partition` is ever called, and raises the same `SplitInputError`.

Each removed block was preceded by `# Anticipates issue #22 (length validation belongs in partition).` — exactly the migration the comment promised.

## What changes

- `src/strategies/GroupKFold.jl`: drop the per-call `length(groups)` check.
- `src/strategies/LeavePGroupsOut.jl`: same.
- `src/strategies/StratifiedKFold.jl`: same for `length(target)`.

`N = numobs(data)` is kept in each — still used downstream (e.g. `[i for i = 1:N if !(i in test_set)]`).

## Coverage

Each strategy already has a `@test_throws DataSplits.SplitInputError` for the mismatched-length case (`test/test-group-kfold.jl:83`, `test/test-leave-p-groups-out.jl:55`, `test/test-stratified-kfold.jl:109`). Those tests now exercise the centralised path; the assertion is on the error type, not on the message text, so coverage is unchanged.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
