### PR TITLE
feat: add PredefinedSplit cross-validation

### DIFF
--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -23,6 +23,7 @@ include("strategies/KFold.jl")
 include("strategies/LeavePOut.jl")
 include("strategies/LeavePGroupsOut.jl")
 include("strategies/StratifiedKFold.jl")
+include("strategies/PredefinedSplit.jl")
 
 # Core API
 export partition
@@ -53,6 +54,7 @@ export GroupShuffleSplit, GroupStratifiedSplit
 # Cross-validation
 export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut
 export StratifiedKFold
+export PredefinedSplit
 
 # Target / time property
 export TargetPropertySplit, TargetPropertyHigh, TargetPropertyLow

--- a/src/strategies/PredefinedSplit.jl
+++ b/src/strategies/PredefinedSplit.jl
@@ -1,0 +1,68 @@
+"""
+    PredefinedSplit(test_fold::AbstractVector{<:Integer}) <: AbstractCVStrategy
+
+Cross-validation with caller-provided fold assignments. Each entry of
+`test_fold` gives the fold ID in which the corresponding observation
+serves as **test**. Negative values mean the observation is **never**
+placed in the test cohort — it is part of every fold's training set.
+
+Folds are produced in ascending order of fold ID. Mirrors
+scikit-learn's `PredefinedSplit`, but driven by `partition` and
+DataSplits' `CrossValidationSplit` result type.
+
+# Fields
+- `test_fold::Vector{Int}`: Length-`N` vector mapping each observation to
+  the fold ID where it tests, or to a negative value for "always train".
+
+# Notes
+- `length(test_fold)` must equal `numobs(data)`.
+- Fold IDs need not be contiguous; what matters is the set of distinct
+  non-negative values. At least one non-negative ID must exist.
+
+# Examples
+```julia
+# Three folds: obs 1-2 test in fold 0, obs 3-4 test in fold 1, obs 5-6
+# test in fold 2.
+test_fold = [0, 0, 1, 1, 2, 2]
+cvs = partition(X, PredefinedSplit(test_fold))
+
+# Hold-out style: obs 7-10 are reserved for training only across all folds.
+test_fold = [0, 0, 0, 1, 1, 1, -1, -1, -1, -1]
+cvs = partition(X, PredefinedSplit(test_fold))
+```
+"""
+struct PredefinedSplit <: AbstractCVStrategy
+  test_fold::Vector{Int}
+end
+
+PredefinedSplit(test_fold::AbstractVector{<:Integer}) =
+  PredefinedSplit(collect(Int, test_fold))
+
+consumes(::PredefinedSplit) = ()
+fallback_from_data(::PredefinedSplit) = ()
+
+function _partition(data, alg::PredefinedSplit; kwargs...)
+  N = numobs(data)
+  length(alg.test_fold) == N || throw(
+    SplitInputError(
+      "PredefinedSplit: `test_fold` length ($(length(alg.test_fold))) does not match number of observations ($N).",
+    ),
+  )
+
+  fold_ids = sort!(unique(f for f in alg.test_fold if f >= 0))
+  isempty(fold_ids) && throw(
+    SplitParameterError(
+      "PredefinedSplit requires at least one non-negative fold ID in `test_fold`; all entries were negative.",
+    ),
+  )
+
+  folds = Vector{TrainTestSplit{Vector{Int}}}(undef, length(fold_ids))
+  for (k, f) in enumerate(fold_ids)
+    test_idx = findall(==(f), alg.test_fold)
+    train_idx = findall(!=(f), alg.test_fold)
+    # Observations marked with a negative fold are part of train for every fold.
+    # `findall(!=(f))` already includes them since they never equal a non-negative `f`.
+    folds[k] = TrainTestSplit(train_idx, test_idx)
+  end
+  return CrossValidationSplit(folds)
+end

--- a/test/test-predefined-split.jl
+++ b/test/test-predefined-split.jl
@@ -1,0 +1,74 @@
+using Test
+using DataSplits
+import DataSplits: SplitInputError, SplitParameterError
+
+@testset "PredefinedSplit" begin
+  X = rand(4, 12)
+
+  @testset "Basic three-fold assignment" begin
+    test_fold = [0, 0, 1, 1, 2, 2, 0, 1, 2, 0, 1, 2]
+    cvs = partition(X, PredefinedSplit(test_fold))
+
+    @test length(folds(cvs)) == 3
+    # Each observation tests exactly once.
+    test_concat = reduce(vcat, [f.test for f in folds(cvs)])
+    @test sort(test_concat) == 1:12
+    # Within a fold, train ∩ test is empty and train ∪ test = 1:12.
+    for f in folds(cvs)
+      @test isempty(intersect(f.train, f.test))
+      @test sort(vcat(f.train, f.test)) == 1:12
+    end
+  end
+
+  @testset "Negative IDs mean train-only" begin
+    # Obs 7-12 are training-only.
+    test_fold = [0, 0, 1, 1, 2, 2, -1, -1, -1, -1, -1, -1]
+    cvs = partition(X, PredefinedSplit(test_fold))
+
+    @test length(folds(cvs)) == 3
+    # Train-only indices appear in every fold's train cohort.
+    for f in folds(cvs)
+      @test all(i -> i in f.train, 7:12)
+      @test isempty(intersect(f.test, 7:12))
+    end
+    # Test indices across folds cover only obs 1-6.
+    test_concat = sort(reduce(vcat, [f.test for f in folds(cvs)]))
+    @test test_concat == 1:6
+  end
+
+  @testset "Fold IDs need not be contiguous" begin
+    test_fold = [10, 10, 20, 20, 50, 50]
+    cvs = partition(rand(2, 6), PredefinedSplit(test_fold))
+    @test length(folds(cvs)) == 3
+    # Folds emitted in ascending order of ID.
+    @test folds(cvs)[1].test == [1, 2]
+    @test folds(cvs)[2].test == [3, 4]
+    @test folds(cvs)[3].test == [5, 6]
+  end
+
+  @testset "Length mismatch raises SplitInputError" begin
+    @test_throws SplitInputError partition(X, PredefinedSplit([0, 0, 1, 1]))
+  end
+
+  @testset "All-negative fold IDs raise SplitParameterError" begin
+    @test_throws SplitParameterError partition(
+      X,
+      PredefinedSplit(fill(-1, 12)),
+    )
+  end
+
+  @testset "Construction accepts any integer vector" begin
+    cvs = partition(X, PredefinedSplit(Int8[0, 0, 1, 1, 2, 2, 0, 1, 2, 0, 1, 2]))
+    @test length(folds(cvs)) == 3
+  end
+
+  @testset "splitview round-trip" begin
+    test_fold = [0, 0, 0, 1, 1, 1, 2, 2, 2, 0, 1, 2]
+    cvs = partition(X, PredefinedSplit(test_fold))
+    for (Xtr, Xte) in splitview(cvs, X)
+      @test size(Xtr, 1) == 4
+      @test size(Xte, 1) == 4
+      @test size(Xtr, 2) + size(Xte, 2) == 12
+    end
+  end
+end


### PR DESCRIPTION
Closes part of #27.

## Contract

```julia
PredefinedSplit(test_fold::AbstractVector{<:Integer}) <: AbstractCVStrategy
```

Caller-provided fold assignments. `test_fold[i]` gives the fold ID where observation `i` serves as **test**. Negative entries mean "always train" — that observation appears in every fold's training cohort and never in test (sklearn's `-1` convention).

```julia
test_fold = [0, 0, 1, 1, 2, 2]
cvs = partition(X, PredefinedSplit(test_fold))   # 3 folds

# Hold-out style: obs 7-10 are train-only across every fold
test_fold = [0, 0, 0, 1, 1, 1, -1, -1, -1, -1]
cvs = partition(X, PredefinedSplit(test_fold))   # 2 folds
```

## Design notes

- **Slot vs. struct field**. The fold assignment lives on the struct, not as a `partition` kwarg. `(:data, :target, :time, :groups)` are about *what role a vector plays in the algorithm*; `test_fold` is the algorithm itself, not a feature. Putting it on the struct keeps the trait surface clean (`consumes = ()`, `fallback_from_data = ()`).
- **Length validation**. Done in `_partition` since `_resolve_slot` (post-#35) only sees the four canonical slots. Same `SplitInputError` shape and message style as the centralised check.
- **Fold ordering**. Folds are emitted in ascending order of ID. IDs need not be contiguous (`[10, 10, 20, 20, 50, 50]` works); only the set of distinct non-negative values matters.

## Tests

`test/test-predefined-split.jl` (32 tests):
- Three-fold round-trip on a 12-obs dataset.
- Negative IDs → train-only across all folds.
- Non-contiguous IDs preserve ascending fold order.
- Length mismatch → `SplitInputError`.
- All-negative `test_fold` → `SplitParameterError`.
- Construction from non-`Int` integer vectors (`Int8`).
- `splitview` round-trip preserves observation counts.

Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
