### PR TITLE
feat: add ShuffleSplit cross-validation

### DIFF
--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -23,10 +23,12 @@ include("strategies/KFold.jl")
 include("strategies/LeavePOut.jl")
 include("strategies/LeavePGroupsOut.jl")
 include("strategies/StratifiedKFold.jl")
+include("strategies/ShuffleSplit.jl")
 
 # Core API
 export partition
 export AbstractSplitResult, AbstractSplitStrategy, AbstractCVStrategy
+export AbstractResamplingCVStrategy
 export splitdata, splitview
 export trainindices, testindices, valindices, folds
 
@@ -53,6 +55,7 @@ export GroupShuffleSplit, GroupStratifiedSplit
 # Cross-validation
 export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut
 export StratifiedKFold
+export ShuffleSplit
 
 # Target / time property
 export TargetPropertySplit, TargetPropertyHigh, TargetPropertyLow

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -23,11 +23,8 @@ include("strategies/KFold.jl")
 include("strategies/LeavePOut.jl")
 include("strategies/LeavePGroupsOut.jl")
 include("strategies/StratifiedKFold.jl")
-<<<<<<< feat/cv-shuffle-split
 include("strategies/ShuffleSplit.jl")
-=======
 include("strategies/PredefinedSplit.jl")
->>>>>>> api
 
 # Core API
 export partition
@@ -59,11 +56,8 @@ export GroupShuffleSplit, GroupStratifiedSplit
 # Cross-validation
 export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut
 export StratifiedKFold
-<<<<<<< feat/cv-shuffle-split
 export ShuffleSplit
-=======
 export PredefinedSplit
->>>>>>> api
 
 # Target / time property
 export TargetPropertySplit, TargetPropertyHigh, TargetPropertyLow

--- a/src/core.jl
+++ b/src/core.jl
@@ -45,6 +45,19 @@ To implement a custom CV strategy:
 abstract type AbstractCVStrategy <: AbstractSplitStrategy end
 
 """
+    AbstractResamplingCVStrategy <: AbstractCVStrategy
+
+Abstract supertype for *resampling* cross-validation strategies —
+strategies whose folds are independent random train/test splits sized
+by the caller, rather than fixed slices of a deterministic partition.
+
+Subtyping this routes calls to the `partition(data, alg; train, test, …)`
+method, which forwards the resolved `n_train` / `n_test` to `_partition`.
+Used by `ShuffleSplit` and `StratifiedShuffleSplit`.
+"""
+abstract type AbstractResamplingCVStrategy <: AbstractCVStrategy end
+
+"""
     AbstractSplitResult
 
 Abstract supertype for all split result types.
@@ -613,7 +626,9 @@ fold result per element of the partition.
 
 Unlike the train/test and train/val/test forms, this method does **not**
 accept `train` / `test` / `validation` keywords — fold sizes are fixed by
-the strategy (typically via `k`).
+the strategy (typically via `k`). Resampling strategies that *do* take
+caller-set cohort sizes subtype [`AbstractResamplingCVStrategy`](@ref)
+and dispatch to a separate `partition` method.
 
 # Auxiliary slots
 
@@ -649,6 +664,58 @@ function partition(
   return _partition(
     data_internal,
     alg;
+    target = _slot_for(alg, resolved_target, :target),
+    time = _slot_for(alg, resolved_time, :time),
+    groups = _slot_for(alg, resolved_groups, :groups),
+    rng = rng,
+  )
+end
+
+"""
+    partition(data, alg::AbstractResamplingCVStrategy;
+              train, test,
+              target=nothing, time=nothing, groups=nothing,
+              rng=Random.default_rng()) -> CrossValidationSplit
+
+Resampling cross-validation: each fold is an independent random
+train/test split sized by the caller, and `n_splits` independent
+resamples are produced. Used by `ShuffleSplit` and
+`StratifiedShuffleSplit`.
+
+`train` and `test` follow the same conventions as the train/test
+`partition` form (percentages, absolute counts, or `(0,1)` fractions
+summing to 1).
+
+# Examples
+```julia
+cvs = partition(X, ShuffleSplit(10); train = 0.8, test = 0.2)
+```
+"""
+function partition(
+  data,
+  alg::AbstractResamplingCVStrategy;
+  train::Real,
+  test::Real,
+  target = nothing,
+  time = nothing,
+  groups = nothing,
+  rng = Random.default_rng(),
+)
+  N = _assert_partitionable(data)
+  n_train, _, n_test = _resolve_sizes(N, train, nothing, test)
+
+  algs = (alg,)
+  resolved_target = _resolve_slot(algs, data, target, :target)
+  resolved_time = _resolve_slot(algs, data, time, :time)
+  resolved_groups = _resolve_slot(algs, data, groups, :groups)
+
+  data_internal = :data ∈ consumes(alg) ? _to_feature_matrix(data) : data
+
+  return _partition(
+    data_internal,
+    alg;
+    n_train = n_train,
+    n_test = n_test,
     target = _slot_for(alg, resolved_target, :target),
     time = _slot_for(alg, resolved_time, :time),
     groups = _slot_for(alg, resolved_groups, :groups),

--- a/src/strategies/ShuffleSplit.jl
+++ b/src/strategies/ShuffleSplit.jl
@@ -1,0 +1,65 @@
+"""
+    ShuffleSplit(n_splits::Integer) <: AbstractCVStrategy
+
+Random permutation cross-validation. For each of the `n_splits`
+iterations, observations are randomly shuffled and the requested
+`train` and `test` cohort sizes are drawn from the head and the next
+slice of the permutation. Mirrors scikit-learn's `ShuffleSplit`, with
+the train/test sizes supplied at the `partition` call (in line with
+the rest of DataSplits' API).
+
+# Fields
+- `n_splits::Int`: Number of resamples (must be ≥ 1).
+
+# Notes
+- `train` and `test` sum to `N`, like the rest of the partition API —
+  every observation is placed in exactly one cohort per resample.
+  (sklearn lets you drop observations by setting `train_size + test_size < 1`;
+  this package keeps the "all observations accounted for" invariant.)
+- Resamples are independent: an observation can land in train in one
+  fold and test in another. This is the defining property of
+  `ShuffleSplit` versus `KFold`.
+
+# Examples
+```julia
+# Fractions.
+cvs = partition(X, ShuffleSplit(10); train = 0.8, test = 0.2)
+
+# Absolute counts.
+cvs = partition(X, ShuffleSplit(10); train = 80, test = 20)
+
+# Reproducible.
+cvs = partition(X, ShuffleSplit(10); train = 0.8, test = 0.2,
+                rng = MersenneTwister(42))
+```
+"""
+struct ShuffleSplit <: AbstractResamplingCVStrategy
+  n_splits::Int
+end
+
+ShuffleSplit(n_splits::Integer) = ShuffleSplit(Int(n_splits))
+
+consumes(::ShuffleSplit) = ()
+fallback_from_data(::ShuffleSplit) = ()
+
+function _partition(
+  data,
+  alg::ShuffleSplit;
+  n_train,
+  n_test,
+  rng = Random.default_rng(),
+  kwargs...,
+)
+  alg.n_splits >= 1 || throw(
+    SplitParameterError("ShuffleSplit requires n_splits ≥ 1, got n_splits=$(alg.n_splits)."),
+  )
+
+  N = numobs(data)
+
+  result = Vector{TrainTestSplit{Vector{Int}}}(undef, alg.n_splits)
+  for i = 1:alg.n_splits
+    perm = randperm(rng, N)
+    result[i] = TrainTestSplit(perm[1:n_train], perm[(n_train+1):(n_train+n_test)])
+  end
+  return CrossValidationSplit(result)
+end

--- a/test/test-shuffle-split.jl
+++ b/test/test-shuffle-split.jl
@@ -1,0 +1,73 @@
+using Test
+using Random
+using DataSplits
+import DataSplits: SplitParameterError
+
+@testset "ShuffleSplit" begin
+  X = rand(4, 50)
+
+  @testset "Basic resampling" begin
+    cvs = partition(X, ShuffleSplit(10); train = 0.8, test = 0.2)
+    @test length(folds(cvs)) == 10
+    for f in folds(cvs)
+      @test length(f.train) == 40
+      @test length(f.test) == 10
+      @test isempty(intersect(f.train, f.test))
+      @test sort(vcat(f.train, f.test)) == 1:50
+    end
+  end
+
+  @testset "Resamples are independent (different from KFold)" begin
+    cvs = partition(X, ShuffleSplit(20); train = 0.8, test = 0.2,
+                    rng = MersenneTwister(0))
+    # Across resamples each observation should appear in test multiple times,
+    # not exactly once like in KFold.
+    test_counts = zeros(Int, 50)
+    for f in folds(cvs)
+      for i in f.test
+        test_counts[i] += 1
+      end
+    end
+    @test sum(test_counts) == 20 * 10
+    @test maximum(test_counts) > 1
+  end
+
+  @testset "Absolute counts" begin
+    cvs = partition(X, ShuffleSplit(5); train = 30, test = 20)
+    @test length(folds(cvs)) == 5
+    for f in folds(cvs)
+      @test length(f.train) == 30
+      @test length(f.test) == 20
+    end
+  end
+
+  @testset "Reproducible with rng" begin
+    rng1 = MersenneTwister(42)
+    rng2 = MersenneTwister(42)
+    cvs1 = partition(X, ShuffleSplit(3); train = 0.6, test = 0.4, rng = rng1)
+    cvs2 = partition(X, ShuffleSplit(3); train = 0.6, test = 0.4, rng = rng2)
+    for (a, b) in zip(folds(cvs1), folds(cvs2))
+      @test a.train == b.train
+      @test a.test == b.test
+    end
+  end
+
+  @testset "Missing train/test raises (UndefKeywordError)" begin
+    @test_throws UndefKeywordError partition(X, ShuffleSplit(5))
+    @test_throws UndefKeywordError partition(X, ShuffleSplit(5); train = 0.8)
+    @test_throws UndefKeywordError partition(X, ShuffleSplit(5); test = 0.2)
+  end
+
+  @testset "n_splits validation" begin
+    @test_throws SplitParameterError partition(X, ShuffleSplit(0); train = 0.8, test = 0.2)
+  end
+
+  @testset "splitview round-trip" begin
+    cvs = partition(X, ShuffleSplit(3); train = 0.8, test = 0.2)
+    for (Xtr, Xte) in splitview(cvs, X)
+      @test size(Xtr, 1) == 4
+      @test size(Xte, 1) == 4
+      @test size(Xtr, 2) + size(Xte, 2) == 50
+    end
+  end
+end


### PR DESCRIPTION
Closes part of #27.

## Contract

```julia
ShuffleSplit(n_splits::Integer) <: AbstractResamplingCVStrategy

cvs = partition(X, ShuffleSplit(10); train = 0.8, test = 0.2)
```

Resampling counterpart to `KFold`: `n_splits` independent random train/test draws. Each resample shuffles all N observations and slices off `n_train` / `n_test`. Unlike KFold's exclusive partitioning, an observation can be in train in one resample and test in another.

## Design notes (project-fit deviations from sklearn)

- **Cohort sizes stay on `partition`, not on the struct**, per PR #20's refactor. Sklearn's `ShuffleSplit(test_size=…, train_size=…)` move to `partition(...; train, test)`.
- **All observations accounted for**: `n_train + n_test == N`. Sklearn allows dropping observations (`train + test < 1`); this package keeps the invariant that every obs lands in exactly one cohort per resample.
- **New abstract subtype** `AbstractResamplingCVStrategy <: AbstractCVStrategy`. The CV `partition` method that *rejects* `train`/`test` (KFold, GroupKFold, StratifiedKFold, LeavePOut, LeavePGroupsOut) stays untouched. Resamplers dispatch to a sibling `partition(::AbstractResamplingCVStrategy; train, test, …)` method that *requires* both kwargs. Existing "CV rejects train/test" tests are unaffected; for `ShuffleSplit`, missing kwargs surface naturally as `UndefKeywordError`.
- The new abstract type is exported alongside `AbstractCVStrategy` for custom-strategy authors.

## Files

- `src/core.jl`: defines `AbstractResamplingCVStrategy`, adds the `partition(::AbstractResamplingCVStrategy; train, test, …)` method, and updates the `AbstractCVStrategy` partition docstring to point at it.
- `src/strategies/ShuffleSplit.jl`: the strategy itself.
- `src/DataSplits.jl`: include + `export ShuffleSplit, AbstractResamplingCVStrategy`.
- `test/test-shuffle-split.jl`: 73 tests covering correctness, independence vs KFold, reproducibility, validation, and `splitview` round-trip.

Suite green (full `Pkg.test()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
