### PR TITLE
feat: add BlockedCV cross-validation

### DIFF
--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -26,6 +26,7 @@ include("strategies/StratifiedKFold.jl")
 include("strategies/ShuffleSplit.jl")
 include("strategies/StratifiedShuffleSplit.jl")
 include("strategies/PredefinedSplit.jl")
+include("strategies/BlockedCV.jl")
 
 # Core API
 export partition
@@ -59,6 +60,7 @@ export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroup
 export StratifiedKFold
 export ShuffleSplit, StratifiedShuffleSplit
 export PredefinedSplit
+export BlockedCV
 
 # Target / time property
 export TargetPropertySplit, TargetPropertyHigh, TargetPropertyLow

--- a/src/strategies/BlockedCV.jl
+++ b/src/strategies/BlockedCV.jl
@@ -1,0 +1,125 @@
+"""
+    BlockedCV(k::Integer; gap::Integer=0) <: AbstractCVStrategy
+
+Blocked k-fold cross-validation for dependent (time- or space-ordered)
+data. Observations are sorted by `time=` and partitioned into `k`
+contiguous chronological blocks; each block takes a turn as the test
+cohort while the train cohort is everything **else** — both blocks
+preceding it and blocks following it.
+
+This differs from [`TimeSeriesSplit`](@ref) (forward-only, train always
+precedes test) and from [`KFold`](@ref) (no temporal ordering). It
+matches the "blocked CV" used in time-series / spatial-statistics
+literature (Bergmeir & Benítez 2012, Roberts et al. 2017) when train
+samples should not be drawn from arbitrary positions but the test
+block must still be embedded in a longer train history.
+
+A `gap` window (in observations) is removed from the train cohort on
+**both sides** of the test block to mitigate leakage from
+autocorrelation.
+
+# Atomicity rule
+
+Observations sharing the same timestamp are never split between train
+and test of the same fold — block boundaries fall between distinct
+time values, mirroring [`TimeSeriesSplit`](@ref) and [`TimeSplit`](@ref).
+`gap` is measured in observations and may trim partial blocks of equal
+timestamps from the train side; no row ever leaks into test.
+
+# Fields
+- `k::Int`: Number of folds (must be ≥ 2 and ≤ number of distinct
+  time values).
+- `gap::Int`: Number of observations excluded from the train cohort
+  on each side of the test block (must be ≥ 0; default `0`).
+
+# Examples
+```julia
+# 5-fold blocked CV with a one-observation embargo on both sides.
+cvs = partition(X, BlockedCV(5; gap = 1); time = timestamps)
+
+for (X_train, X_test) in splitview(cvs, X)
+    fit!(model, X_train); evaluate(model, X_test)
+end
+
+# Single-input shorthand when the timestamps are also the data.
+cvs = partition(timestamps, BlockedCV(4))
+```
+"""
+struct BlockedCV <: AbstractCVStrategy
+  k::Int
+  gap::Int
+end
+
+BlockedCV(k::Integer; gap::Integer = 0) = BlockedCV(Int(k), Int(gap))
+
+consumes(::BlockedCV) = (:time,)
+fallback_from_data(::BlockedCV) = (:time,)
+
+function _partition(data, alg::BlockedCV; time, kwargs...)
+  alg.k >= 2 ||
+    throw(SplitParameterError("BlockedCV requires k ≥ 2, got k=$(alg.k)."))
+  alg.gap >= 0 ||
+    throw(SplitParameterError("BlockedCV requires gap ≥ 0, got gap=$(alg.gap)."))
+
+  N = numobs(data)
+
+  # Group observations by identical timestamp (atomic time blocks).
+  date_to_indices = Dict{eltype(time),Vector{Int}}()
+  for (i, t) in enumerate(time)
+    push!(get!(date_to_indices, t, Int[]), i)
+  end
+  sorted_dates = sort!(collect(keys(date_to_indices)))
+  B = length(sorted_dates)
+
+  alg.k <= B || throw(
+    SplitParameterError(
+      "BlockedCV(k=$(alg.k)) requires at least k distinct time values; got $B.",
+    ),
+  )
+
+  # Distribute the B blocks across k chunks balancing the remainder across
+  # the first `B mod k` chunks (np.array_split behaviour).
+  base, rem = divrem(B, alg.k)
+  chunk_block_end = Vector{Int}(undef, alg.k)
+  acc = 0
+  for c = 1:alg.k
+    acc += base + (c <= rem ? 1 : 0)
+    chunk_block_end[c] = acc
+  end
+
+  # Chronological order vector and block→position offsets.
+  order = Int[]
+  block_offset = Vector{Int}(undef, B + 1)
+  block_offset[1] = 0
+  for (b, d) in enumerate(sorted_dates)
+    inds = date_to_indices[d]
+    append!(order, inds)
+    block_offset[b+1] = block_offset[b] + length(inds)
+  end
+
+  result = Vector{TrainTestSplit{Vector{Int}}}(undef, alg.k)
+  for i = 1:alg.k
+    test_block_start = i == 1 ? 1 : chunk_block_end[i-1] + 1
+    test_block_end = chunk_block_end[i]
+
+    test_lo = block_offset[test_block_start] + 1
+    test_hi = block_offset[test_block_end+1]
+
+    # Train side: everything outside [test_lo - gap, test_hi + gap].
+    train_left_hi = test_lo - 1 - alg.gap
+    train_right_lo = test_hi + 1 + alg.gap
+
+    train_left = train_left_hi >= 1 ? order[1:train_left_hi] : Int[]
+    train_right = train_right_lo <= N ? order[train_right_lo:N] : Int[]
+    train_idx = vcat(train_left, train_right)
+
+    !isempty(train_idx) || throw(
+      SplitParameterError(
+        "BlockedCV: fold $i has empty train cohort (gap=$(alg.gap) too large for the surrounding blocks).",
+      ),
+    )
+
+    result[i] = TrainTestSplit(train_idx, order[test_lo:test_hi])
+  end
+  return CrossValidationSplit(result)
+end

--- a/test/test-blocked-cv.jl
+++ b/test/test-blocked-cv.jl
@@ -1,0 +1,95 @@
+using Test, Random, DataSplits, Dates
+import DataSplits: SplitParameterError
+
+@testset "BlockedCV" begin
+  N = 50
+  ts = collect(1:N)
+  X = randn(2, N)
+
+  @testset "Basic contract: k folds, train ∪ test == 1:N" begin
+    cvs = partition(X, BlockedCV(5); time = ts)
+    @test length(folds(cvs)) == 5
+    for f in folds(cvs)
+      @test isempty(intersect(f.train, f.test))
+      @test sort(vcat(f.train, f.test)) == 1:N
+    end
+  end
+
+  @testset "Train is bidirectional (unlike TimeSeriesSplit)" begin
+    cvs = partition(X, BlockedCV(5); time = ts)
+    fs = folds(cvs)
+    # Middle folds should have train both before and after the test block.
+    middle = fs[3]
+    train_min, train_max = extrema(ts[middle.train])
+    test_min, test_max = extrema(ts[middle.test])
+    @test train_min < test_min
+    @test train_max > test_max
+  end
+
+  @testset "Test cohorts tile the timeline disjointly" begin
+    cvs = partition(X, BlockedCV(5); time = ts)
+    test_concat = sort(reduce(vcat, [f.test for f in folds(cvs)]))
+    @test test_concat == 1:N
+  end
+
+  @testset "Remainder distributed across chunks" begin
+    # B=23, k=5 → 23÷5=4 r 3, so block sizes 5,5,5,4,4.
+    ts23 = collect(1:23)
+    data = randn(2, 23)
+    cvs = partition(data, BlockedCV(5); time = ts23)
+    test_sizes = [length(f.test) for f in folds(cvs)]
+    @test test_sizes == [5, 5, 5, 4, 4]
+  end
+
+  @testset "gap removes observations on both sides of the test block" begin
+    cvs = partition(X, BlockedCV(5; gap = 2); time = ts)
+    fs = folds(cvs)
+    middle = fs[3]
+    test_min, test_max = extrema(ts[middle.test])
+    # No train observation lies within gap of the test block.
+    for t in ts[middle.train]
+      @test t < test_min - 2 || t > test_max + 2
+    end
+  end
+
+  @testset "Boundary folds: first fold has no left side, last fold no right side" begin
+    cvs = partition(X, BlockedCV(5); time = ts)
+    fs = folds(cvs)
+    @test minimum(ts[fs[1].test]) == 1
+    @test maximum(ts[fs[end].test]) == N
+    @test maximum(ts[fs[1].train]) > maximum(ts[fs[1].test])  # only right side
+    @test minimum(ts[fs[end].train]) < minimum(ts[fs[end].test])  # only left side
+  end
+
+  @testset "Atomicity by timestamp" begin
+    ts_rep = repeat(1:10, inner = 3)
+    data = randn(2, length(ts_rep))
+    cvs = partition(data, BlockedCV(2); time = ts_rep)
+    for f in folds(cvs)
+      train_ts = unique(ts_rep[f.train])
+      test_ts = unique(ts_rep[f.test])
+      @test isempty(intersect(train_ts, test_ts))
+    end
+  end
+
+  @testset "Date timestamps" begin
+    dates = Date(2024, 1, 1) .+ Day.(0:(N-1))
+    cvs = partition(X, BlockedCV(4); time = dates)
+    @test length(folds(cvs)) == 4
+  end
+
+  @testset "Fallback: time as both data and time" begin
+    cvs = partition(ts, BlockedCV(4))
+    @test length(folds(cvs)) == 4
+  end
+
+  @testset "Parameter validation" begin
+    @test_throws SplitParameterError partition(X, BlockedCV(1); time = ts)
+    @test_throws SplitParameterError partition(X, BlockedCV(5; gap = -1); time = ts)
+    @test_throws SplitParameterError partition(randn(2, 3), BlockedCV(5); time = [1, 2, 3])
+  end
+
+  @testset "gap consuming the train cohort errors" begin
+    @test_throws SplitParameterError partition(X, BlockedCV(2; gap = N); time = ts)
+  end
+end


### PR DESCRIPTION
Closes part of #28 (Blocked Cross-Validation for dependent data).

## Contract

\`\`\`julia
BlockedCV(k::Integer; gap::Integer=0) <: AbstractCVStrategy

cvs = partition(X, BlockedCV(5; gap = 1); time = timestamps)
\`\`\`

## How it differs from existing strategies

| Strategy | Order | Train relative to test | Use case |
|---|---|---|---|
| \`KFold\` | position | bidirectional | i.i.d. data |
| \`TimeSeriesSplit\` | time | forward-only | true forecasting |
| **\`BlockedCV\`** | **time** | **bidirectional with optional gap** | **dependent data where the test block must be embedded in train history (Bergmeir & Benítez 2012, Roberts et al. 2017)** |

## Algorithm

1. Group observations by identical timestamp into atomic blocks (same atomicity rule as \`TimeSeriesSplit\` / \`TimeSplit\`).
2. Distribute B blocks across k chunks with sklearn-style \`np.array_split\` balancing (remainder spread across the first \`B mod k\` chunks).
3. For each fold \`i\`: test = chunk \`i\`; train = everything outside \`[test_lo - gap, test_hi + gap]\` — both the left side (earlier observations) and the right side (later observations) of the test block.

## Tests

\`test/test-blocked-cv.jl\` (63 tests):
- Basic contract: \`train ∪ test == 1:N\`, disjoint within fold.
- Train is bidirectional (middle fold has train both before and after test).
- Test cohorts tile the timeline disjointly.
- Remainder distribution: \`B=23, k=5\` → \`[5,5,5,4,4]\`.
- \`gap\` excluded on both sides of test block.
- Boundary folds: first has no left side, last no right side.
- Atomicity under repeated timestamps.
- \`Date\` timestamps.
- Fallback (time as both data and time).
- Parameter validation: \`k ≥ 2\`, \`gap ≥ 0\`, \`k ≤ distinct time values\`.
- \`gap\` consuming the train cohort errors.

Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)