### PR TITLE
feat: add BootstrapSplit cross-validation

### DIFF
--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -26,6 +26,7 @@ include("strategies/StratifiedKFold.jl")
 include("strategies/ShuffleSplit.jl")
 include("strategies/StratifiedShuffleSplit.jl")
 include("strategies/PredefinedSplit.jl")
+include("strategies/BootstrapSplit.jl")
 
 # Core API
 export partition
@@ -59,6 +60,7 @@ export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroup
 export StratifiedKFold
 export ShuffleSplit, StratifiedShuffleSplit
 export PredefinedSplit
+export BootstrapSplit
 
 # Target / time property
 export TargetPropertySplit, TargetPropertyHigh, TargetPropertyLow

--- a/src/strategies/BootstrapSplit.jl
+++ b/src/strategies/BootstrapSplit.jl
@@ -1,0 +1,72 @@
+"""
+    BootstrapSplit(n_splits::Integer) <: AbstractCVStrategy
+
+Bootstrap cross-validation. For each of `n_splits` iterations the
+train cohort is drawn from `1:N` with replacement (so it has exactly
+`N` indices, with duplicates), and the test cohort is the set of
+**out-of-bag (OOB)** observations — the unique indices that were not
+sampled. On average about `(1 - 1/e) ≈ 63.2%` of unique observations
+land in train; the remaining `~36.8%` form the OOB test.
+
+# Fields
+- `n_splits::Int`: Number of bootstrap resamples (must be ≥ 1).
+
+# Important notes
+
+- **Train contains duplicates by design.** This is the defining
+  property of bootstrap sampling — it lets the model see the variance
+  introduced by resampling the empirical distribution. If you need
+  unique-only train indices use [`ShuffleSplit`](@ref) instead.
+- **Test (OOB) size varies fold-to-fold.** It is whatever the
+  bootstrap left out; no caller-set size is honoured.
+- Cohort sizes (`train`, `test`) are not accepted: train is always
+  `N` (with replacement), test is the OOB.
+- Almost surely non-empty test for `N ≥ 2` (probability of all `N`
+  indices being drawn at least once falls off as `N! / N^N`).
+
+# Examples
+```julia
+# 50 bootstrap resamples.
+cvs = partition(X, BootstrapSplit(50); rng = MersenneTwister(42))
+
+for (X_train, X_test) in splitview(cvs, X)
+    fit!(model, X_train)        # X_train has N obs, with duplicates
+    evaluate(model, X_test)     # X_test is the OOB
+end
+```
+"""
+struct BootstrapSplit <: AbstractCVStrategy
+  n_splits::Int
+end
+
+BootstrapSplit(n_splits::Integer) = BootstrapSplit(Int(n_splits))
+
+consumes(::BootstrapSplit) = ()
+fallback_from_data(::BootstrapSplit) = ()
+
+function _partition(data, alg::BootstrapSplit; rng = Random.default_rng(), kwargs...)
+  alg.n_splits >= 1 || throw(
+    SplitParameterError(
+      "BootstrapSplit requires n_splits ≥ 1, got n_splits=$(alg.n_splits).",
+    ),
+  )
+
+  N = numobs(data)
+
+  result = Vector{TrainTestSplit{Vector{Int}}}(undef, alg.n_splits)
+  for i = 1:alg.n_splits
+    train_idx = rand(rng, 1:N, N)
+    in_bag = falses(N)
+    for j in train_idx
+      in_bag[j] = true
+    end
+    test_idx = findall(!, in_bag)
+    !isempty(test_idx) || throw(
+      SplitParameterError(
+        "BootstrapSplit: resample $i drew every observation; out-of-bag test cohort is empty. Try a different rng or a larger N.",
+      ),
+    )
+    result[i] = TrainTestSplit(train_idx, test_idx)
+  end
+  return CrossValidationSplit(result)
+end

--- a/test/test-bootstrap-split.jl
+++ b/test/test-bootstrap-split.jl
@@ -1,0 +1,57 @@
+using Test, Random, DataSplits
+import DataSplits: SplitParameterError
+
+@testset "BootstrapSplit" begin
+  N = 60
+  X = randn(2, N)
+
+  @testset "Produces n_splits folds" begin
+    cvs = partition(X, BootstrapSplit(20); rng = MersenneTwister(0))
+    @test length(folds(cvs)) == 20
+  end
+
+  @testset "Train has exactly N indices (with duplicates)" begin
+    cvs = partition(X, BootstrapSplit(10); rng = MersenneTwister(0))
+    for f in folds(cvs)
+      @test length(f.train) == N
+      @test length(unique(f.train)) < N  # duplicates almost sure for moderate N
+    end
+  end
+
+  @testset "Test is the out-of-bag (no overlap with train, unique)" begin
+    cvs = partition(X, BootstrapSplit(10); rng = MersenneTwister(0))
+    for f in folds(cvs)
+      @test length(unique(f.test)) == length(f.test)
+      @test isempty(intersect(Set(f.train), Set(f.test)))
+      @test sort(collect(union(Set(f.train), Set(f.test)))) == 1:N
+    end
+  end
+
+  @testset "OOB share is roughly 1 - 1/e on average" begin
+    cvs = partition(X, BootstrapSplit(200); rng = MersenneTwister(42))
+    oob_fractions = [length(f.test) / N for f in folds(cvs)]
+    avg = sum(oob_fractions) / length(oob_fractions)
+    # Theoretical limit ≈ 0.368; allow a generous tolerance.
+    @test 0.30 <= avg <= 0.44
+  end
+
+  @testset "Resamples differ from each other" begin
+    cvs = partition(X, BootstrapSplit(5); rng = MersenneTwister(0))
+    fs = folds(cvs)
+    @test fs[1].train != fs[2].train
+    @test fs[1].test != fs[2].test
+  end
+
+  @testset "Reproducible with seeded rng" begin
+    a = partition(X, BootstrapSplit(5); rng = MersenneTwister(7))
+    b = partition(X, BootstrapSplit(5); rng = MersenneTwister(7))
+    for (x, y) in zip(folds(a), folds(b))
+      @test x.train == y.train
+      @test x.test == y.test
+    end
+  end
+
+  @testset "Parameter validation" begin
+    @test_throws SplitParameterError partition(X, BootstrapSplit(0))
+  end
+end


### PR DESCRIPTION
Closes part of #28 (Cross-Validation with Bootstrapping).

## Contract

\`\`\`julia
BootstrapSplit(n_splits::Integer) <: AbstractCVStrategy

cvs = partition(X, BootstrapSplit(50); rng = MersenneTwister(42))
\`\`\`

For each of \`n_splits\` resamples:
- **Train**: \`N\` indices drawn from \`1:N\` with replacement (duplicates expected by design).
- **Test**: the out-of-bag (OOB) — unique indices that were not sampled. Size varies fold-to-fold; on average ~36.8% of \`N\` (\`1 - 1/e\`).

No \`train\` / \`test\` kwargs are accepted: train is always \`N\` (with replacement), test is the OOB.

## Design notes

- **Duplicates in train are the defining property** of bootstrap sampling — they let the model see the variance introduced by resampling the empirical distribution. Users wanting unique-only train indices should use \`ShuffleSplit\` instead. Documented prominently in the docstring.
- Errors if a resample happens to draw every observation (empty OOB). Almost surely non-empty for \`N ≥ 2\` but kept as a defensive check.
- \`<: AbstractCVStrategy\` (not \`AbstractResamplingCVStrategy\`) because there are no caller-set cohort sizes.

## Tests

\`test/test-bootstrap-split.jl\` (65 tests):
- Produces \`n_splits\` folds.
- Train has exactly \`N\` indices with duplicates.
- Test is the unique OOB, disjoint from train, \`train ∪ test == 1:N\`.
- Average OOB share over 200 resamples falls in \`[0.30, 0.44]\` around the theoretical \`1 - 1/e\`.
- Successive resamples differ.
- Reproducibility under a seeded \`rng\`.
- Parameter validation: \`n_splits ≥ 1\`.

Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)