### PR TITLE
Utilities to interface with MLJ and Flux

### DIFF
--- a/notebooks/tutorial.jl
+++ b/notebooks/tutorial.jl
@@ -1,0 +1,179 @@
+### A Pluto.jl notebook ###
+# v0.20.25
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ a2b3c4d5-e6f7-4901-2345-bcdef0123456
+begin
+  import Pkg
+  Pkg.develop(path = joinpath(@__DIR__, ".."))
+  Pkg.add(["MLJ", "MLJDecisionTreeInterface", "Flux", "DataFrames", "CategoricalArrays"])
+
+  using DataSplits
+  import DataSplits: partition     # MLJ also exports partition; pin to DataSplits
+  using MLJ
+  import MLJDecisionTreeInterface   # registers DecisionTreeClassifier with MLJ
+  using Flux
+  using DataFrames, CategoricalArrays
+  using Random, Statistics
+end
+
+# ╔═╡ f1e2d3c4-b5a6-4890-1234-abcdef012345
+md"""
+# DataSplits.jl — Integration with MLJ and Flux
+
+**DataSplits.jl** provides data-splitting and cross-validation strategies that return plain
+index vectors, composable with any Julia ML framework.
+
+| Section | Strategy | Framework | Task |
+|---------|----------|-----------|------|
+| 1 — Cross-validation | `StratifiedKFold` | **MLJ** | Classification |
+| 2 — Train / test split | `RandomSplit` | **Flux** | Regression |
+
+Swap any strategy without touching the training code.
+
+> **Run this notebook** by opening it with [Pluto.jl](https://plutojl.org/).
+> Pluto will install all required packages automatically.
+"""
+
+# ╔═╡ c4d5e6f7-a8b9-4123-4567-def012345678
+md"""
+---
+## 1 — Cross-validation with MLJ
+
+We build a **binary classification** dataset with an 80 / 20 class imbalance and use
+`StratifiedKFold` to guarantee every fold mirrors the global class ratio.
+
+Plain `KFold` shuffles observations uniformly and can produce folds where the minority
+class is under- or over-represented, masking the true generalisation error.
+Replacing `StratifiedKFold` with `KFold` below is a one-word change.
+"""
+
+# ╔═╡ d5e6f7a8-b9c0-4234-5678-ef0123456789
+begin
+  rng_cls = Xoshiro(42)
+  n_a, n_b = 320, 80
+
+  X_cls = DataFrame(
+    x1 = vcat(randn(rng_cls, n_a), randn(rng_cls, n_b) .+ 3.0),
+    x2 = vcat(randn(rng_cls, n_a), randn(rng_cls, n_b) .+ 3.0),
+  )
+  y_cls = categorical(vcat(fill("A", n_a), fill("B", n_b)))
+
+  "$(nrow(X_cls)) observations  |  class A: $n_a ($(n_a*100÷(n_a+n_b))%)  |  class B: $n_b ($(n_b*100÷(n_a+n_b))%)"
+end
+
+# ╔═╡ f7a8b9c0-d1e2-4456-789a-012345678901
+begin
+  DecisionTreeClassifier = @load DecisionTreeClassifier pkg = DecisionTree verbosity = 0
+  tree = DecisionTreeClassifier(max_depth = 4)
+
+  # rowpairs converts the CrossValidationSplit into the (train, test) tuple format
+  # that MLJ's evaluate! accepts natively via the resampling= keyword.
+  mach = machine(tree, X_cls, y_cls)
+  cv_result = evaluate!(
+    mach;
+    resampling = rowpairs(y_cls, StratifiedKFold(5); rng = rng_cls),
+    measure = accuracy,
+    verbosity = 0,
+  )
+  fold_accuracies = cv_result.per_fold[1]
+end
+
+# ╔═╡ a8b9c0d1-e2f3-4567-89ab-123456789012
+md"""
+**Per-fold accuracy:** $(join(string.(round.(fold_accuracies .* 100; digits=1)) .* "%", "  ·  "))
+
+**Cross-validated accuracy:** $(round(mean(fold_accuracies) * 100; digits=1))%
+± $(round(std(fold_accuracies) * 100; digits=1))%
+
+Each test fold contains ≈ $(round(Int, n_b / (n_a + n_b) * 100))% class-B observations —
+matching the global ratio, guaranteed by `StratifiedKFold`.
+"""
+
+# ╔═╡ b9c0d1e2-f3a4-4678-9abc-234567890123
+md"""
+---
+## 2 — Train / test split with Flux
+
+A **regression** task: approximate a noisy nonlinear function of four features with
+a small MLP. `RandomSplit` gives an 80 / 20 split; you could replace it with
+`KennardStoneSplit` (maximally diverse training set) or `StratifiedShuffleSplit`
+(repeated random splits with target stratification).
+
+DataSplits uses the **features × samples** convention — columns are observations —
+which matches Flux's `Dense` layer directly.
+"""
+
+# ╔═╡ c0d1e2f3-a4b5-4789-abcd-345678901234
+begin
+  rng_reg = Xoshiro(123)
+  n_reg, n_features = 600, 4
+
+  X_reg = randn(rng_reg, Float32, n_features, n_reg)
+  y_reg =
+    sin.(X_reg[1, :]) .+ 0.5f0 .* X_reg[2, :] .+ 0.1f0 .* randn(rng_reg, Float32, n_reg)
+
+  "X: $(size(X_reg))  |  y: $(length(y_reg)) values"
+end
+
+# ╔═╡ d1e2f3a4-b5c6-4890-bcde-456789012345
+begin
+  # train=80, test=20 means 80% / 20% (integers summing to 100 are percentages).
+  split_reg = partition(X_reg, RandomSplit(); train = 80, test = 20, rng = rng_reg)
+
+  # trainview / testview extract a cohort from multiple sources in one call.
+  # The tuple returned by trainview passes directly to Flux.DataLoader.
+  X_train, y_train = trainview(split_reg, X_reg, y_reg)
+  X_test, y_test = testview(split_reg, X_reg, y_reg)
+
+  "Train: $(size(X_train))  |  Test: $(size(X_test))"
+end
+
+# ╔═╡ e2f3a4b5-c6d7-4901-cdef-567890123456
+begin
+  model = Chain(Dense(n_features => 64, relu), Dense(64 => 32, relu), Dense(32 => 1))
+  # Dense(32 => 1) outputs shape (1, batch); vec collapses it to a vector to match y.
+  mse(m, x, y) = Flux.mse(vec(m(x)), y)
+
+  opt_state = Flux.setup(Adam(1.0f-3), model)
+  # trainview returns a tuple — pass it directly without unpacking.
+  loader =
+    Flux.DataLoader(trainview(split_reg, X_reg, y_reg); batchsize = 64, shuffle = true)
+
+  for _ = 1:300
+    for (xb, yb) in loader
+      grads = Flux.gradient(model) do m
+        Flux.mse(vec(m(xb)), yb)
+      end
+      Flux.update!(opt_state, model, grads[1])
+    end
+  end
+
+  train_mse = mse(model, X_train, y_train)
+  test_mse = mse(model, X_test, y_test)
+
+  (; train_mse = round(train_mse; digits = 4), test_mse = round(test_mse; digits = 4))
+end
+
+# ╔═╡ f3a4b5c6-d7e8-4012-def0-678901234567
+md"""
+| Cohort | MSE |
+|--------|-----|
+| Train  | $(round(train_mse; digits = 4)) |
+| Test   | $(round(test_mse;  digits = 4)) |
+"""
+
+# ╔═╡ Cell order:
+# ╟─f1e2d3c4-b5a6-4890-1234-abcdef012345
+# ╠═a2b3c4d5-e6f7-4901-2345-bcdef0123456
+# ╟─c4d5e6f7-a8b9-4123-4567-def012345678
+# ╠═d5e6f7a8-b9c0-4234-5678-ef0123456789
+# ╠═f7a8b9c0-d1e2-4456-789a-012345678901
+# ╟─a8b9c0d1-e2f3-4567-89ab-123456789012
+# ╟─b9c0d1e2-f3a4-4678-9abc-234567890123
+# ╠═c0d1e2f3-a4b5-4789-abcd-345678901234
+# ╠═d1e2f3a4-b5c6-4890-bcde-456789012345
+# ╠═e2f3a4b5-c6d7-4901-cdef-567890123456
+# ╟─f3a4b5c6-d7e8-4012-def0-678901234567

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -39,6 +39,8 @@ export partition
 export AbstractSplitResult, AbstractSplitStrategy, AbstractCVStrategy
 export AbstractResamplingCVStrategy
 export splitdata, splitview
+export trainview, testview, valview
+export traindata, testdata, valdata
 export trainindices, testindices, valindices, folds, rowpairs
 
 # Trait interface (for custom strategy authors)

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -39,7 +39,7 @@ export partition
 export AbstractSplitResult, AbstractSplitStrategy, AbstractCVStrategy
 export AbstractResamplingCVStrategy
 export splitdata, splitview
-export trainindices, testindices, valindices, folds
+export trainindices, testindices, valindices, folds, rowpairs
 
 # Trait interface (for custom strategy authors)
 export consumes, fallback_from_data
@@ -62,7 +62,8 @@ export RandomSplit
 export GroupShuffleSplit, GroupStratifiedSplit
 
 # Cross-validation
-export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut, TimeSeriesSplit
+export GroupKFold,
+  KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut, TimeSeriesSplit
 export StratifiedKFold
 export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut
 export StratifiedKFold, StratifiedGroupKFold

--- a/src/core.jl
+++ b/src/core.jl
@@ -159,6 +159,22 @@ Return the individual fold results from a cross-validation split.
 """
 folds(res::CrossValidationSplit) = res.folds
 
+"""
+    rowpairs(res::CrossValidationSplit) -> Vector{Tuple{Vector{Int}, Vector{Int}}}
+
+Convert a cross-validation split into the `(train_indices, test_indices)` pair
+format accepted by MLJ's `evaluate!` `resampling=` keyword.
+
+# Example
+```julia
+cvs = partition(X, StratifiedKFold(5); target = y)
+mach = machine(model, X, y)
+evaluate!(mach; resampling = rowpairs(cvs), measure = accuracy)
+```
+"""
+rowpairs(res::CrossValidationSplit) =
+  [(trainindices(fold), testindices(fold)) for fold in folds(res)]
+
 
 # ---------------------------------------------------------------------------
 # Data extraction

--- a/src/core.jl
+++ b/src/core.jl
@@ -177,6 +177,87 @@ rowpairs(res::CrossValidationSplit) =
 
 
 # ---------------------------------------------------------------------------
+# Single-cohort, multi-source extraction
+# ---------------------------------------------------------------------------
+
+_co_views(idxs, data) = obsview(data, idxs)
+_co_views(idxs, d1, d2, rest...) = map(d -> obsview(d, idxs), (d1, d2, rest...))
+
+_co_data(idxs, data) = getobs(data, idxs)
+_co_data(idxs, d1, d2, rest...) = map(d -> getobs(d, idxs), (d1, d2, rest...))
+
+"""
+    trainview(res, data...)
+    testview(res, data...)
+    valview(res, data...)
+
+Return lazy views of the requested cohort for one or more data sources.
+
+When called with a **single** data source, returns the view directly.
+When called with **two or more**, returns a `Tuple` of views — suitable for
+passing directly to `Flux.DataLoader` or similar.
+
+`valview` is only defined for `TrainValTestSplit`.
+
+For `CrossValidationSplit`, each function returns a `Vector` (one element per fold).
+
+# Examples
+```julia
+# Single source
+X_train = trainview(split, X)
+X_test  = testview(split, X)
+
+# Multiple sources — tuple destructures naturally
+X_train, y_train = trainview(split, X, y)
+X_test,  y_test  = testview(split, X, y)
+
+# Flux DataLoader — tuple passed directly
+loader = Flux.DataLoader(trainview(split, X, y); batchsize = 64, shuffle = true)
+
+# Train/val/test
+X_train, y_train = trainview(split3, X, y)
+X_val,   y_val   = valview(split3,   X, y)
+X_test,  y_test  = testview(split3,  X, y)
+
+# Cross-validation
+for (X_tr, y_tr) in trainview(cvs, X, y)
+    loader = Flux.DataLoader((X_tr, y_tr); batchsize = 64)
+    # ...
+end
+```
+"""
+trainview(r::TrainTestSplit, data...) = _co_views(r.train, data...)
+testview(r::TrainTestSplit, data...) = _co_views(r.test, data...)
+
+trainview(r::TrainValTestSplit, data...) = _co_views(r.train, data...)
+valview(r::TrainValTestSplit, data...) = _co_views(r.val, data...)
+testview(r::TrainValTestSplit, data...) = _co_views(r.test, data...)
+
+trainview(r::CrossValidationSplit, data...) =
+  [trainview(fold, data...) for fold in folds(r)]
+testview(r::CrossValidationSplit, data...) = [testview(fold, data...) for fold in folds(r)]
+
+"""
+    traindata(res, data...)
+    testdata(res, data...)
+    valdata(res, data...)
+
+Like [`trainview`](@ref) / [`testview`](@ref) / [`valview`](@ref) but materialises
+copies via `getobs` rather than returning lazy views.
+"""
+traindata(r::TrainTestSplit, data...) = _co_data(r.train, data...)
+testdata(r::TrainTestSplit, data...) = _co_data(r.test, data...)
+
+traindata(r::TrainValTestSplit, data...) = _co_data(r.train, data...)
+valdata(r::TrainValTestSplit, data...) = _co_data(r.val, data...)
+testdata(r::TrainValTestSplit, data...) = _co_data(r.test, data...)
+
+traindata(r::CrossValidationSplit, data...) =
+  [traindata(fold, data...) for fold in folds(r)]
+testdata(r::CrossValidationSplit, data...) = [testdata(fold, data...) for fold in folds(r)]
+
+
+# ---------------------------------------------------------------------------
 # Data extraction
 # ---------------------------------------------------------------------------
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -160,10 +160,12 @@ Return the individual fold results from a cross-validation split.
 folds(res::CrossValidationSplit) = res.folds
 
 """
-    rowpairs(res::CrossValidationSplit) -> Vector{Tuple{Vector{Int}, Vector{Int}}}
+    rowpairs(res) -> Vector{Tuple{Vector{Int}, Vector{Int}}}
 
 Convert a cross-validation split into the `(train_indices, test_indices)` pair
 format accepted by MLJ's `evaluate!` `resampling=` keyword.
+
+When used on TrainValTestSplit it returns (train, val)
 
 # Example
 ```julia
@@ -174,6 +176,20 @@ evaluate!(mach; resampling = rowpairs(cvs), measure = accuracy)
 """
 rowpairs(res::CrossValidationSplit) =
   [(trainindices(fold), testindices(fold)) for fold in folds(res)]
+
+rowpairs(res::TrainTestSplit) = [(trainindices(res), testindices(res))]
+
+rowpairs(res::TrainValTestSplit) = [(trainindices(res), valindices(res))]
+
+"""
+    rowpairs(data, alg::AbstractSplitStrategy; kwargs...)
+
+Convenience wrapper equivalent to:
+
+    rowpairs(partition(data, alg; kwargs...))
+"""
+rowpairs(data, alg::AbstractSplitStrategy; kwargs...) =
+  rowpairs(partition(data, alg; kwargs...))
 
 
 # ---------------------------------------------------------------------------

--- a/test/test-result-types.jl
+++ b/test/test-result-types.jl
@@ -73,3 +73,20 @@ end
     @test X_test == X[:, folds_vec[i].test]
   end
 end
+@testset "rowpairs" begin
+  folds_vec = [
+    TrainTestSplit([1, 2, 3], [4, 5]),
+    TrainTestSplit([4, 5, 1], [2, 3]),
+    TrainTestSplit([2, 3, 4], [1, 5]),
+  ]
+  cvs = CrossValidationSplit(folds_vec)
+  pairs = rowpairs(cvs)
+
+  @test pairs isa Vector
+  @test length(pairs) == 3
+  @test all(p -> p isa Tuple{Vector{Int},Vector{Int}}, pairs)
+  for (i, (tr, te)) in enumerate(pairs)
+    @test tr == folds_vec[i].train
+    @test te == folds_vec[i].test
+  end
+end

--- a/test/test-result-types.jl
+++ b/test/test-result-types.jl
@@ -90,3 +90,143 @@ end
     @test te == folds_vec[i].test
   end
 end
+
+@testset "trainview / testview — TrainTestSplit single-arg" begin
+  X = rand(3, 10)
+  r = TrainTestSplit([1, 2, 3, 4, 5, 6, 7, 8], [9, 10])
+
+  tv = trainview(r, X)
+  @test tv == X[:, r.train]
+  @test parent(tv) === X          # obsview — shares memory
+
+  tev = testview(r, X)
+  @test tev == X[:, r.test]
+  @test parent(tev) === X
+end
+
+@testset "trainview / testview — TrainTestSplit multi-arg" begin
+  X = rand(3, 10)
+  y = rand(10)
+  r = TrainTestSplit([1, 2, 3, 4, 5, 6, 7, 8], [9, 10])
+
+  Xtr, ytr = trainview(r, X, y)
+  @test Xtr == X[:, r.train]
+  @test ytr == y[r.train]
+  @test parent(Xtr) === X
+  @test parent(ytr) === y
+
+  Xte, yte = testview(r, X, y)
+  @test Xte == X[:, r.test]
+  @test yte == y[r.test]
+end
+
+@testset "trainview / valview / testview — TrainValTestSplit" begin
+  X = rand(3, 10)
+  y = rand(10)
+  r = TrainValTestSplit([1, 2, 3, 4, 5, 6, 7], [8], [9, 10])
+
+  @test trainview(r, X) == X[:, r.train]
+  @test valview(r, X) == X[:, r.val]
+  @test testview(r, X) == X[:, r.test]
+
+  Xtr, ytr = trainview(r, X, y)
+  Xval, yval = valview(r, X, y)
+  Xte, yte = testview(r, X, y)
+  @test Xtr == X[:, r.train]
+  @test ytr == y[r.train]
+  @test Xval == X[:, r.val]
+  @test yval == y[r.val]
+  @test Xte == X[:, r.test]
+  @test yte == y[r.test]
+end
+
+@testset "traindata / testdata — TrainTestSplit" begin
+  X = rand(3, 10)
+  y = rand(10)
+  r = TrainTestSplit([1, 2, 3, 4, 5, 6, 7, 8], [9, 10])
+
+  Xtr = traindata(r, X)
+  @test Xtr == X[:, r.train]
+  @test !(Xtr === X)              # getobs — materialised copy
+
+  Xtr2, ytr2 = traindata(r, X, y)
+  @test Xtr2 == X[:, r.train]
+  @test ytr2 == y[r.train]
+
+  Xte2, yte2 = testdata(r, X, y)
+  @test Xte2 == X[:, r.test]
+  @test yte2 == y[r.test]
+end
+
+@testset "traindata / valdata / testdata — TrainValTestSplit" begin
+  X = rand(3, 10)
+  y = rand(10)
+  r = TrainValTestSplit([1, 2, 3, 4, 5, 6, 7], [8], [9, 10])
+
+  @test traindata(r, X) == X[:, r.train]
+  @test valdata(r, X) == X[:, r.val]
+  @test testdata(r, X) == X[:, r.test]
+
+  Xtr, ytr = traindata(r, X, y)
+  Xval, yval = valdata(r, X, y)
+  Xte, yte = testdata(r, X, y)
+  @test Xtr == X[:, r.train]
+  @test ytr == y[r.train]
+  @test Xval == X[:, r.val]
+  @test yval == y[r.val]
+  @test Xte == X[:, r.test]
+  @test yte == y[r.test]
+end
+
+@testset "trainview / testview — CrossValidationSplit" begin
+  X = rand(3, 10)
+  y = rand(10)
+  folds_vec = [
+    TrainTestSplit([1, 2, 3, 4, 5, 6, 7], [8, 9, 10]),
+    TrainTestSplit([1, 2, 3, 8, 9, 10], [4, 5, 6, 7]),
+  ]
+  cvs = CrossValidationSplit(folds_vec)
+
+  tv = trainview(cvs, X)
+  @test length(tv) == 2
+  for (i, v) in enumerate(tv)
+    @test v == X[:, folds_vec[i].train]
+  end
+
+  tev = testview(cvs, X)
+  @test length(tev) == 2
+  for (i, v) in enumerate(tev)
+    @test v == X[:, folds_vec[i].test]
+  end
+
+  # multi-source
+  tv2 = trainview(cvs, X, y)
+  @test length(tv2) == 2
+  for (i, (Xv, yv)) in enumerate(tv2)
+    @test Xv == X[:, folds_vec[i].train]
+    @test yv == y[folds_vec[i].train]
+  end
+end
+
+@testset "traindata / testdata — CrossValidationSplit" begin
+  X = rand(3, 10)
+  y = rand(10)
+  folds_vec = [
+    TrainTestSplit([1, 2, 3, 4, 5, 6, 7], [8, 9, 10]),
+    TrainTestSplit([1, 2, 3, 8, 9, 10], [4, 5, 6, 7]),
+  ]
+  cvs = CrossValidationSplit(folds_vec)
+
+  td = traindata(cvs, X)
+  @test length(td) == 2
+  for (i, v) in enumerate(td)
+    @test v == X[:, folds_vec[i].train]
+  end
+
+  td2 = traindata(cvs, X, y)
+  @test length(td2) == 2
+  for (i, (Xv, yv)) in enumerate(td2)
+    @test Xv == X[:, folds_vec[i].train]
+    @test yv == y[folds_vec[i].train]
+  end
+end


### PR DESCRIPTION
Closes #46 and #47. Added utility functions to easily pass splits to MLJ and Flux.

Added a tutorial Pluto Notebook which shows how to split data and pass it to MLJ and Flux.