### PR TITLE
feat: add GroupShuffleSplitCV cross-validation

### DIFF
--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -32,6 +32,7 @@ include("strategies/RepeatedKFold.jl")
 include("strategies/RepeatedStratifiedKFold.jl")
 include("strategies/TimeSeriesSplit.jl")
 include("strategies/StratifiedGroupKFold.jl")
+include("strategies/GroupShuffleSplitCV.jl")
 
 
 # Core API
@@ -69,7 +70,7 @@ export GroupKFold,
 export StratifiedKFold
 export GroupKFold, KFold, LeavePOut, LeaveOneOut, LeavePGroupsOut, LeaveOneGroupOut
 export StratifiedKFold, StratifiedGroupKFold
-export ShuffleSplit, StratifiedShuffleSplit
+export ShuffleSplit, StratifiedShuffleSplit, GroupShuffleSplitCV
 export PredefinedSplit
 export BootstrapSplit
 export BlockedCV

--- a/src/strategies/GroupShuffleSplitCV.jl
+++ b/src/strategies/GroupShuffleSplitCV.jl
@@ -1,0 +1,91 @@
+using Random
+
+"""
+    GroupShuffleSplitCV(n_splits::Integer) <: AbstractResamplingCVStrategy
+
+Group-aware random permutation cross-validation. For each of `n_splits`
+iterations the groups are shuffled and assigned whole into the train cohort
+until the requested training size is reached; the remaining groups form the
+test cohort. Mirrors scikit-learn's `GroupShuffleSplit`.
+
+Groups are passed as a vector of membership IDs via the `groups=` keyword
+(or, by fallback, `data` itself plays that role).
+
+# Fields
+- `n_splits::Int`: Number of resamples (must be ≥ 1).
+
+# Notes
+- **Resamples are independent** — a group can land in train in one fold and
+  test in another. This is the defining property versus [`GroupKFold`](@ref),
+  where each group appears in exactly one test cohort across folds.
+- Because groups are added whole, the actual train cohort size may overshoot
+  the requested `n_train` (same behaviour as the 2-cohort
+  [`GroupShuffleSplit`](@ref)).
+- `train` and `test` must sum to `N`; every observation is placed in
+  exactly one cohort per resample.
+
+# Examples
+```julia
+# Fractions.
+cvs = partition(X, GroupShuffleSplitCV(10);
+                groups = patient_ids, train = 0.8, test = 0.2)
+
+# Absolute counts.
+cvs = partition(X, GroupShuffleSplitCV(10);
+                groups = patient_ids, train = 80, test = 20)
+
+# Reproducible.
+cvs = partition(X, GroupShuffleSplitCV(10);
+                groups = patient_ids, train = 0.8, test = 0.2,
+                rng = MersenneTwister(42))
+
+# Fallback: ids are simultaneously the data and the groups.
+cvs = partition(patient_ids, GroupShuffleSplitCV(10);
+                train = 0.8, test = 0.2)
+```
+"""
+struct GroupShuffleSplitCV <: AbstractResamplingCVStrategy
+  n_splits::Int
+end
+
+GroupShuffleSplitCV(n_splits::Integer) = GroupShuffleSplitCV(Int(n_splits))
+
+consumes(::GroupShuffleSplitCV) = (:groups,)
+fallback_from_data(::GroupShuffleSplitCV) = (:groups,)
+
+function _partition(
+  data,
+  alg::GroupShuffleSplitCV;
+  groups,
+  n_train,
+  n_test,
+  rng = Random.default_rng(),
+  kwargs...,
+)
+  alg.n_splits >= 1 || throw(
+    SplitParameterError(
+      "GroupShuffleSplitCV requires n_splits ≥ 1, got n_splits=$(alg.n_splits).",
+    ),
+  )
+
+  sorted_keys, perm = groupsortperm(groups)
+  off = group_offsets(sorted_keys, perm, groups)
+  n_groups = length(sorted_keys)
+
+  result = Vector{TrainTestSplit{Vector{Int}}}(undef, alg.n_splits)
+  for i = 1:alg.n_splits
+    block_order = shuffle(rng, collect(1:n_groups))
+    train_pos = Int[]
+    test_pos = Int[]
+    for b in block_order
+      idxs = perm[(off[b]+1):off[b+1]]
+      if length(train_pos) < n_train
+        append!(train_pos, idxs)
+      else
+        append!(test_pos, idxs)
+      end
+    end
+    result[i] = TrainTestSplit(train_pos, test_pos)
+  end
+  return CrossValidationSplit(result)
+end

--- a/test/test-group-shuffle-split-cv.jl
+++ b/test/test-group-shuffle-split-cv.jl
@@ -1,0 +1,130 @@
+using Test
+using Random
+using DataSplits
+import DataSplits: SplitParameterError
+
+@testset "GroupShuffleSplitCV" begin
+  N = 120
+  X = randn(2, N)
+  groups = vcat(fill(:a, 40), fill(:b, 40), fill(:c, 40))
+
+  @testset "Produces n_splits folds" begin
+    cvs = partition(
+      X,
+      GroupShuffleSplitCV(10);
+      groups = groups,
+      train = 80,
+      test = 40,
+      rng = MersenneTwister(0),
+    )
+    @test length(folds(cvs)) == 10
+  end
+
+  @testset "Each fold is a full partition with no group leakage" begin
+    cvs = partition(
+      X,
+      GroupShuffleSplitCV(8);
+      groups = groups,
+      train = 80,
+      test = 40,
+      rng = MersenneTwister(1),
+    )
+    for f in folds(cvs)
+      @test is_disjoint(f)
+      @test total_size(f) == N
+      @test no_group_leakage(f, groups)
+    end
+  end
+
+  @testset "Resamples are independent (different from GroupKFold)" begin
+    cvs = partition(
+      X,
+      GroupShuffleSplitCV(30);
+      groups = groups,
+      train = 80,
+      test = 40,
+      rng = MersenneTwister(2),
+    )
+    # Across resamples a group should appear in test more than once,
+    # not exactly once like in GroupKFold.
+    test_counts = Dict(g => 0 for g in unique(groups))
+    for f in folds(cvs)
+      for g in unique(groups[testindices(f)])
+        test_counts[g] += 1
+      end
+    end
+    @test maximum(values(test_counts)) > 1
+  end
+
+  @testset "Train size may overshoot (whole-group invariant)" begin
+    cvs = partition(
+      X,
+      GroupShuffleSplitCV(5);
+      groups = groups,
+      train = 50,
+      test = 70,
+      rng = MersenneTwister(3),
+    )
+    for f in folds(cvs)
+      # groups are size 40 each, so train fills with a multiple of 40 ≥ 50.
+      @test length(trainindices(f)) >= 50
+      @test total_size(f) == N
+    end
+  end
+
+  @testset "Reproducible with seeded rng" begin
+    a = partition(
+      X,
+      GroupShuffleSplitCV(5);
+      groups = groups,
+      train = 80,
+      test = 40,
+      rng = MersenneTwister(7),
+    )
+    b = partition(
+      X,
+      GroupShuffleSplitCV(5);
+      groups = groups,
+      train = 80,
+      test = 40,
+      rng = MersenneTwister(7),
+    )
+    for (x, y) in zip(folds(a), folds(b))
+      @test same_indices(x, y)
+    end
+  end
+
+  @testset "Fallback: ids as both data and groups" begin
+    ids = vcat(fill(:a, 40), fill(:b, 40), fill(:c, 40))
+    cvs = partition(
+      ids,
+      GroupShuffleSplitCV(4);
+      train = 80,
+      test = 40,
+      rng = MersenneTwister(11),
+    )
+    @test length(folds(cvs)) == 4
+    for f in folds(cvs)
+      @test total_size(f) == N
+      @test is_disjoint(f)
+    end
+  end
+
+  @testset "n_splits validation" begin
+    @test_throws SplitParameterError partition(
+      X,
+      GroupShuffleSplitCV(0);
+      groups = groups,
+      train = 80,
+      test = 40,
+    )
+  end
+
+  @testset "Missing train/test raises (UndefKeywordError)" begin
+    @test_throws UndefKeywordError partition(
+      X,
+      GroupShuffleSplitCV(5);
+      groups = groups,
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `GroupShuffleSplitCV(n_splits) <: AbstractResamplingCVStrategy`, the group-aware random permutation CV equivalent to scikit-learn's `GroupShuffleSplit`.
- Uses the `*CV` suffix per your call on #27 (Option 2: `GroupShuffleSplitCV`) — keeps the existing 2-cohort `GroupShuffleSplit` untouched.
- Behaviour: each of `n_splits` iterations independently shuffles the groups and accumulates whole groups into train until `n_train` is reached; remaining groups form test. As with `GroupShuffleSplit`, train may overshoot the requested size by up to one group.
- `consumes = (:groups,)`, `fallback_from_data = (:groups,)` — single-input shorthand (`partition(ids, GroupShuffleSplitCV(10); train, test)`) supported.

Closes #27.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` passes the new `GroupShuffleSplitCV` testset (52/52).
- [x] Full suite green on top of `api` HEAD (`cf50e04`).
- [x] Covered: fold count, full-partition + group-leakage invariants per fold, independence across resamples (group can test in >1 fold), overshoot behaviour, reproducibility with seeded RNG, single-input fallback, `n_splits ≥ 1` validation, missing `train`/`test` keyword error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)