### PR TITLE
docs: refresh 02-getting-started for the current partition API

### DIFF
--- a/docs/src/02-getting-started.md
+++ b/docs/src/02-getting-started.md
@@ -6,24 +6,102 @@ CurrentModule = DataSplits
 
 ## Basic API
 
-- `split(data, strategy)`: main entry point.
-- `data`: array, tuple `(X,)` or `(X, y)`.
-- `strategy`: subtype of `SplitStrategy`.
+DataSplits exposes a single entry point, `partition`, in three forms:
 
-## Data Formats
+```julia
+# Two cohorts (train / test).
+res = partition(data, alg; train, test, kwargs...)
 
-- Accepts matrices, arrays, tables, or custom types.
-- **Important:** DataSplits expects matrices to be in the Julia ML convention: columns are samples, rows are features. If your data uses rows as samples, transpose it before splitting (e.g., use `X'`).
-- For custom data types, implement `Base.length` (number of samples) and `Base.getindex(data, i)` (returning the i-th sample) as described in the [MLUtils documentation](https://juliaml.github.io/MLUtils.jl).
+# Three cohorts (train / validation / test) — two strategies.
+res = partition(data, test_alg, val_alg; train, validation, test, kwargs...)
 
-## Robust Index Handling
+# Cross-validation — returns a CrossValidationSplit of folds.
+cvs = partition(data, cv_alg; kwargs...)
+```
 
-All splitting strategies in DataSplits are robust to arrays with arbitrary axes (e.g., OffsetArrays, SubArrays, etc.). The library automatically handles mapping between user-facing indices and internal positions, so you can use any AbstractArray as input.
+`alg` is any subtype of [`AbstractSplitStrategy`](@ref); CV strategies subtype [`AbstractCVStrategy`](@ref). Cohort sizes (`train`, `validation`, `test`) live on `partition`, not on the strategy struct.
 
-## Randomness Control
+## Cohort sizes
 
-Pass `rng` keyword to strategies supporting it, e.g. `split(X, RandomSplit(0.7); rng=123)`.
+`train`, `validation`, and `test` accept either absolute integer counts (summing to `numobs(data)`), integer percentages (summing to `100`), or `(0, 1)` fractions (summing to `1.0`). Mixing is allowed as long as the resolved counts are each ≥ 1 and sum to `N`.
 
-## Example: Custom Data Type
+```julia
+partition(X, RandomSplit(); train = 80, test = 20)        # absolute
+partition(X, RandomSplit(); train = 80, test = 20)        # percentages (when N != 100)
+partition(X, RandomSplit(); train = 0.8, test = 0.2)      # fractions
+```
 
-To use your own data type, implement `sample_indices(data)` and `get_sample(data, i)`.
+CV strategies do not take `train`/`test` keywords — fold sizes are determined by the strategy itself (typically through `k` or `n_splits`). Resampling CV strategies (subtypes of [`AbstractResamplingCVStrategy`](@ref) such as `ShuffleSplit`) are the exception: they do accept `train`/`test`, applied per fold.
+
+## Data formats
+
+`data` can be a matrix, a vector, a Tables.jl-compatible container (e.g. `DataFrame`), or any custom type implementing the `MLUtils` interface (`MLUtils.numobs`, `MLUtils.getobs`).
+
+For matrices DataSplits follows the Julia ML convention: **columns are samples, rows are features**. Transpose row-major data before passing it in (`X'` or `permutedims(X)`). For Tables.jl inputs rows are samples — DataSplits converts internally when a strategy needs an F×N matrix.
+
+All returned indices are positive integers in `1:N`. For non-standard arrays or custom containers, materialise subsets with `splitdata` / `splitview` rather than indexing directly.
+
+## Auxiliary slots
+
+Strategies declare which auxiliary inputs they consume via the `consumes` trait. The three slots are:
+
+- `target` — response / property vector (e.g. for `SPXYSplit`, `StratifiedKFold`).
+- `time` — temporal ordering vector (e.g. for `TimeSplit`, `TimeSeriesSplit`, `BlockedCV`).
+- `groups` — group-membership vector (e.g. for `GroupShuffleSplit`, `GroupKFold`).
+
+```julia
+partition(X, SPXYSplit(); target = y, train = 80, test = 20)
+partition(X, GroupKFold(5); groups = patient_ids)
+partition(X, TimeSeriesSplit(5); time = timestamps)
+```
+
+### Single-input shorthand
+
+When `data` is itself the vector a strategy needs (e.g. a timestamps vector for `TimeSplit`, or group IDs for `GroupShuffleSplit`), the corresponding keyword may be omitted — `data` plays both roles. This is governed by the `fallback_from_data` trait.
+
+```julia
+partition(timestamps, TimeSplit(); train = 0.7, test = 0.3)
+partition(patient_ids, GroupShuffleSplit(); train = 0.8, test = 0.2)
+```
+
+## Randomness
+
+Strategies that randomise (e.g. `RandomSplit`, `ShuffleSplit`, `GroupShuffleSplit`) accept an `rng` keyword for reproducibility:
+
+```julia
+using Random
+partition(X, RandomSplit(); train = 0.8, test = 0.2, rng = MersenneTwister(42))
+```
+
+## Materialising splits
+
+`partition` returns indices, not data subsets. Use one of:
+
+- [`splitdata(res, data)`](@ref) — returns a tuple of independent copies via `MLUtils.getobs`.
+- [`splitview(res, data)`](@ref) — returns lazy slices via `MLUtils.obsview` (no copy).
+- [`trainview`](@ref) / [`testview`](@ref) / [`valview`](@ref) — lazy view of a single cohort across one or more data sources.
+- [`traindata`](@ref) / [`testdata`](@ref) / [`valdata`](@ref) — materialised counterparts.
+
+```julia
+res = partition(X, KennardStoneSplit(); train = 0.8, test = 0.2)
+X_train, X_test = splitdata(res, X)
+X_train_view, X_test_view = splitview(res, X)
+X_train, y_train = trainview(res, X, y)   # multi-source tuple
+```
+
+For a `CrossValidationSplit`, `splitdata` / `splitview` return one element per fold:
+
+```julia
+cvs = partition(X, KFold(5))
+for (X_tr, X_te) in splitview(cvs, X)
+    # train and evaluate
+end
+```
+
+## Result accessors
+
+Always read indices through the stable accessors rather than the result's fields directly:
+
+- [`trainindices`](@ref) / [`testindices`](@ref) / [`valindices`](@ref)
+- [`folds`](@ref) for `CrossValidationSplit`
+- [`rowpairs`](@ref) for MLJ-style `(train, test)` tuples


### PR DESCRIPTION
## Summary

First page of the docs spine refresh. The current `02-getting-started.md` still describes the pre-refactor `split(data, strategy)` entry point, `SplitStrategy`, fraction on the struct, etc. — none of which match the API users actually see today.

Rewritten to cover:

- `partition` as the single entry point in three forms — 2-cohort, 3-cohort, CV.
- Cohort sizes (`train` / `validation` / `test`) on `partition`, with integer / percentage / fraction conventions.
- Auxiliary slots (`target`, `time`, `groups`) and the `fallback_from_data` single-input shorthand, with concrete examples for each.
- Randomness control via `rng`.
- Materialisation: `splitdata` / `splitview` / `trainview` / `testview` / `valview` (+ materialised counterparts).
- Stable result accessors (`trainindices`, `testindices`, `valindices`, `folds`, `rowpairs`).

Tone and section layout follow the existing strategy pages (`07-kennard-stone.md`, `10-optisim.md`, etc.) — short prose paragraphs, code blocks, `@ref` cross-references.

## Plan

This is PR 1 of a 4-PR spine refresh — `02-getting-started` → `03-core-api-reference` → `05-extending-data-splits` → `index.md`. Wanted to validate structure and tone with you on a small page first; happy to revise either before propagating the same approach to the rest.

Part of the broader docs refresh tracked alongside #19.

## Test plan

- [ ] `julia --project=docs docs/make.jl` builds without `Cannot resolve @ref` errors after PR #49 lands (cluster pages still block the build before #49 merges).
- [ ] All cross-references resolve to currently-exported names with docstrings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)