### PR TITLE
docs: bind cohort accessor aliases so @ref resolves

### DIFF
--- a/docs/src/80-extending.md
+++ b/docs/src/80-extending.md
@@ -13,7 +13,7 @@ DataSplits is built around a small extension protocol: subtype an abstract strat
    - [`AbstractCVStrategy`](@ref) — cross-validation strategies whose fold sizes are fixed by the strategy itself (typically via `k`).
    - [`AbstractResamplingCVStrategy`](@ref) — CV strategies whose folds are independent random splits sized by the caller (`train`/`test` per fold).
 2. Declare the auxiliary slots your strategy reads with [`consumes`](@ref) and (optionally) [`fallback_from_data`](@ref).
-3. Implement [`_partition`](@ref) with the signature matching your supertype.
+3. Implement `_partition` with the signature matching your supertype.
 4. Add a test file under `test/test-<name>.jl` — `test/runtests.jl` discovers any `test-*.jl` automatically.
 5. Update `src/DataSplits.jl` to `include` the new file and export the strategy.
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -255,6 +255,9 @@ trainview(r::CrossValidationSplit, data...) =
   [trainview(fold, data...) for fold in folds(r)]
 testview(r::CrossValidationSplit, data...) = [testview(fold, data...) for fold in folds(r)]
 
+@doc (@doc trainview) testview
+@doc (@doc trainview) valview
+
 """
     traindata(res, data...)
     testdata(res, data...)
@@ -273,6 +276,9 @@ testdata(r::TrainValTestSplit, data...) = _co_data(r.test, data...)
 traindata(r::CrossValidationSplit, data...) =
   [traindata(fold, data...) for fold in folds(r)]
 testdata(r::CrossValidationSplit, data...) = [testdata(fold, data...) for fold in folds(r)]
+
+@doc (@doc traindata) testdata
+@doc (@doc traindata) valdata
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the Documenter build failure on PR #59 (\`api → main\`).

\`makedocs\` was aborting at the \`cross_references\` step because five \`@ref\` links could not be resolved:

- \`testview\`, \`valview\` — referenced in \`docs/src/02-getting-started.md\` and \`docs/src/95-reference.md\`
- \`testdata\`, \`valdata\` — referenced in \`docs/src/02-getting-started.md\`
- \`_partition\` — referenced in \`docs/src/80-extending.md:16\`

Root cause: Documenter binds a grouped docstring only to the first method that follows. The shared docstrings in \`src/core.jl\` were attached to \`trainview\` / \`traindata\`, leaving \`testview\` / \`valview\` / \`testdata\` / \`valdata\` as docstring-less bindings.

## Changes

- \`src/core.jl\`: attach the existing docstrings to all aliases via \`@doc (@doc trainview) testview\` / etc.
- \`docs/src/80-extending.md\`: \`_partition\` is an internal hook (the contract is documented inline in the same file). Downgrade the \`@ref\` link to plain backticks.

## Test plan

- [x] \`julia --project=docs docs/make.jl\` — completes without \`cross_references\` errors.
- [x] \`julia --project=. -e 'using Pkg; Pkg.test()'\` — all suites pass.
- [ ] CI: Docs job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)