### PR TITLE
fix: make NestedCV constructor an inner ctor to avoid precompile error

### DIFF
--- a/src/strategies/NestedCV.jl
+++ b/src/strategies/NestedCV.jl
@@ -120,17 +120,24 @@ cvs = partition(X, NestedCV(GroupKFold(5), GroupKFold(3)); groups = patient_ids)
 struct NestedCV{O<:AbstractCVStrategy,I<:AbstractCVStrategy} <: AbstractCVStrategy
   outer::O
   inner::I
+  function NestedCV{O,I}(
+    outer::O,
+    inner::I,
+  ) where {O<:AbstractCVStrategy,I<:AbstractCVStrategy}
+    inner isa AbstractResamplingCVStrategy && throw(
+      SplitParameterError(
+        "NestedCV: inner strategy must be a non-resampling AbstractCVStrategy (got $(typeof(inner))). " *
+        "Resampling strategies require caller-set cohort sizes which NestedCV does not propagate.",
+      ),
+    )
+    new{O,I}(outer, inner)
+  end
 end
 
-function NestedCV(outer::AbstractCVStrategy, inner::AbstractCVStrategy)
-  inner isa AbstractResamplingCVStrategy && throw(
-    SplitParameterError(
-      "NestedCV: inner strategy must be a non-resampling AbstractCVStrategy (got $(typeof(inner))). " *
-      "Resampling strategies require caller-set cohort sizes which NestedCV does not propagate.",
-    ),
-  )
-  NestedCV{typeof(outer),typeof(inner)}(outer, inner)
-end
+NestedCV(
+  outer::O,
+  inner::I,
+) where {O<:AbstractCVStrategy,I<:AbstractCVStrategy} = NestedCV{O,I}(outer, inner)
 
 function consumes(nc::NestedCV)
   seen = Symbol[]


### PR DESCRIPTION
## Summary

Removes the \`Method overwriting is not permitted during Module precompilation\` error visible in the docs CI log of PR #59.

The parametric struct

\`\`\`julia
struct NestedCV{O<:AbstractCVStrategy,I<:AbstractCVStrategy} <: AbstractCVStrategy
\`\`\`

already auto-generates an outer constructor whose signature collapses to \`(::AbstractCVStrategy, ::AbstractCVStrategy)\` — exactly the signature of the explicit validation constructor that followed. Defining both shadows the first and triggers the precompile error.

## Fix

Move the resampling-inner check into an **inner constructor** and provide a thin parametric outer wrapper. Behaviour is identical (same error path, same struct contract); precompile is silent.

## Test plan

- [x] \`julia --project=. -e 'using Pkg; Pkg.precompile()'\` — no \`Method overwriting\` warning.
- [x] \`julia --project=. -e 'using Pkg; Pkg.test()'\` — all suites pass, including the existing resampling-inner error-path test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)