### PR TITLE
Add CombinatorialPurgedKFold

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -159,6 +159,8 @@ for N in [1000, 5000]
     @benchmarkable partition($X, BlockedCV(5); time = $times)
   SUITE["time_cv"]["PurgedKFold"][tag] =
     @benchmarkable partition($X, PurgedKFold(5); time = $times)
+  SUITE["time_cv"]["CombinatorialPurgedKFold"][tag] =
+    @benchmarkable partition($X, CombinatorialPurgedKFold(6, 2); time = $times)
 end
 
 # ── Leave-p-out ───────────────────────────────────────────────────────────────

--- a/docs/src/17-cpcv.md
+++ b/docs/src/17-cpcv.md
@@ -1,0 +1,72 @@
+```@meta
+CurrentModule = DataSplits
+```
+
+# Combinatorial Purged K-Fold
+
+**Combinatorial Purged K-Fold (CPCV)** (López de Prado 2018) generalises
+[`PurgedKFold`](@ref) by exhaustively testing *all combinations* of `n_test_folds`
+out of `k` time-ordered blocks rather than testing each block exactly once. This
+produces C(k, n_test_folds) train/test pairs and eliminates the path-dependency of
+standard walk-forward validation.
+
+## Motivation
+
+Standard walk-forward CV (including [`PurgedKFold`](@ref)) evaluates the model on
+each temporal block exactly once, in a fixed order. The performance estimate is
+therefore a single path through the data — it depends on the specific temporal
+order in which the folds appear. Two practitioners using the same model and the same
+data can obtain different estimates simply by choosing different fold boundaries.
+
+CPCV addresses this by averaging over all C(k, n_test_folds) possible test-set
+combinations. The result is a distribution of performance estimates (one per
+combination) rather than a single number, and the average is path-independent.
+
+## How it works
+
+1. Sort observations by `time=` and assign them to `k` contiguous temporal blocks.
+2. Enumerate every combination of `n_test_folds` blocks out of `k` using the
+   combinatorial formula C(k, n_test_folds).
+3. For each combination:
+   - **Test set**: union of the observations in the selected blocks.
+   - **Exclusion zone**: `purge` observations immediately before each test block
+     and `embargo` observations immediately after each test block are removed from
+     train (same semantics as [`PurgedKFold`](@ref)).
+   - **Train set**: all observations outside the test set and exclusion zone.
+4. Return a [`CrossValidationSplit`](@ref) with one fold per combination.
+
+## CPCV vs. PurgedKFold
+
+| | [`PurgedKFold`](@ref) | [`CombinatorialPurgedKFold`](@ref) |
+| --- | --- | --- |
+| Number of folds | k | C(k, n_test_folds) |
+| Each obs in test | Exactly once | C(k−1, n_test_folds−1) times |
+| Path dependency | Yes | No |
+| Provides performance distribution | No | Yes |
+| `n_test_folds = 1` | Equivalent | — |
+
+Setting `n_test_folds = 1` recovers [`PurgedKFold`](@ref) exactly (same k folds,
+same purge and embargo).
+
+## Choosing k and n_test_folds
+
+| Goal | Guidance |
+| --- | --- |
+| Eliminate path dependency, moderate cost | k=6, n_test_folds=2 → 15 folds |
+| Richer performance distribution | k=8, n_test_folds=3 → 56 folds |
+| Reproduce PurgedKFold | n_test_folds=1 |
+| Largest test sets | n_test_folds close to k/2 |
+
+The number of folds grows combinatorially. For k=10 and n_test_folds=4 you get
+C(10,4) = 210 folds — each is fast to evaluate but the total run time is
+proportional to the fold count.
+
+## API reference
+
+- [`CombinatorialPurgedKFold`](@ref)
+- [`PurgedKFold`](@ref)
+
+## References
+
+López de Prado, M. *Advances in Financial Machine Learning*. Wiley, 2018,
+§12 ("Backtesting through Cross-Validation").

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,7 +58,7 @@ end
 | Stratified k-fold | [`StratifiedKFold`](@ref) |
 | Group k-fold | [`GroupKFold`](@ref), [`StratifiedGroupKFold`](@ref) |
 | Leave-group-out | [`LeaveOneGroupOut`](@ref), [`LeavePGroupsOut`](@ref) |
-| Time-series CV | [`TimeSeriesSplit`](@ref), [`BlockedCV`](@ref), [`PurgedKFold`](@ref) |
+| Time-series CV | [`TimeSeriesSplit`](@ref), [`BlockedCV`](@ref), [`PurgedKFold`](@ref), [`CombinatorialPurgedKFold`](@ref) |
 | Resampling CV | [`ShuffleSplit`](@ref), [`StratifiedShuffleSplit`](@ref), [`GroupShuffleSplitCV`](@ref), [`BootstrapSplit`](@ref) |
 | Repeated CV | [`RepeatedKFold`](@ref), [`RepeatedStratifiedKFold`](@ref) |
 | Nested CV | [`NestedCV`](@ref) |

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -34,6 +34,7 @@ include("strategies/TimeSeriesSplit.jl")
 include("strategies/StratifiedGroupKFold.jl")
 include("strategies/NestedCV.jl")
 include("strategies/PurgedKFold.jl")
+include("strategies/CombinatorialPurgedKFold.jl")
 include("strategies/GroupShuffleSplitCV.jl")
 include("strategies/FieldStrengthSplit.jl")
 
@@ -77,6 +78,7 @@ export PredefinedSplit
 export BootstrapSplit
 export NestedCV, NestedFold, innerfolds
 export BlockedCV, PurgedKFold
+export CombinatorialPurgedKFold
 export RepeatedKFold, RepeatedStratifiedKFold
 
 # Target / time property

--- a/src/strategies/CombinatorialPurgedKFold.jl
+++ b/src/strategies/CombinatorialPurgedKFold.jl
@@ -1,0 +1,140 @@
+using Combinatorics: combinations
+
+"""
+    CombinatorialPurgedKFold(k, n_test_folds; purge=0, embargo=0) <: AbstractCVStrategy
+
+Combinatorial Purged k-fold cross-validation (CPCV).
+
+Generalises [`PurgedKFold`](@ref) by exhaustively testing all possible
+combinations of `n_test_folds` out of `k` time-ordered folds, rather than
+testing each fold exactly once.  This produces `C(k, n_test_folds)` train/test
+pairs, each independently purged and embarked, eliminating the path-dependency
+of standard walk-forward validation.
+
+Each test set is the union of `n_test_folds` contiguous time blocks; each train
+set is the complement of the test set and its exclusion windows.  Purging and
+embargo work identically to `PurgedKFold`: `purge` observations immediately
+**before** each test block are removed from train, and `embargo` observations
+immediately **after** each test block are removed.
+
+# Fields
+- `k::Int`: Number of time-ordered folds (must be ≥ 2).
+- `n_test_folds::Int`: Number of folds in each test set (must be ≥ 1 and < k).
+- `purge::Int`: Observations removed from train immediately before each test
+  block (default `0`).
+- `embargo::Int`: Observations removed from train immediately after each test
+  block (default `0`).
+
+# Notes
+- `n_test_folds = 1` is equivalent to [`PurgedKFold`](@ref) (same k folds,
+  same purge/embargo).
+- The number of resulting folds grows combinatorially: `C(k, n_test_folds)`.
+  For `k=6, n_test_folds=2` this gives 15 folds; for `k=8, n_test_folds=3`,
+  56 folds.
+- Average performance across all folds to obtain a path-independent estimate.
+
+# Examples
+```julia
+# 6 time blocks, always test on 2 simultaneously → 15 train/test pairs.
+cvs = partition(X, CombinatorialPurgedKFold(6, 2; purge=1, embargo=1);
+                time = timestamps)
+
+# Equivalent to PurgedKFold(5; purge=1) when n_test_folds=1.
+cvs = partition(X, CombinatorialPurgedKFold(5, 1; purge=1); time = timestamps)
+```
+
+# References
+López de Prado, M. *Advances in Financial Machine Learning*. Wiley, 2018,
+§12 ("Backtesting through Cross-Validation").
+"""
+struct CombinatorialPurgedKFold <: AbstractCVStrategy
+  k::Int
+  n_test_folds::Int
+  purge::Int
+  embargo::Int
+end
+
+function CombinatorialPurgedKFold(
+  k::Integer,
+  n_test_folds::Integer;
+  purge::Integer = 0,
+  embargo::Integer = 0,
+)
+  k >= 2 || throw(SplitParameterError("CombinatorialPurgedKFold requires k ≥ 2, got k=$k."))
+  1 <= n_test_folds < k || throw(
+    SplitParameterError(
+      "CombinatorialPurgedKFold requires 1 ≤ n_test_folds < k, got n_test_folds=$n_test_folds.",
+    ),
+  )
+  purge >= 0 || throw(
+    SplitParameterError("CombinatorialPurgedKFold requires purge ≥ 0, got purge=$purge."),
+  )
+  embargo >= 0 || throw(
+    SplitParameterError(
+      "CombinatorialPurgedKFold requires embargo ≥ 0, got embargo=$embargo.",
+    ),
+  )
+  CombinatorialPurgedKFold(Int(k), Int(n_test_folds), Int(purge), Int(embargo))
+end
+
+consumes(::CombinatorialPurgedKFold) = (:time,)
+fallback_from_data(::CombinatorialPurgedKFold) = (:time,)
+
+function _partition(data, alg::CombinatorialPurgedKFold; time, kwargs...)
+  N = numobs(data)
+  sorted_dates, order = groupsortperm(time)
+  B = length(sorted_dates)
+
+  alg.k <= B || throw(
+    SplitParameterError(
+      "CombinatorialPurgedKFold(k=$(alg.k)) requires at least k=$(alg.k) distinct time values; got $B.",
+    ),
+  )
+
+  chunk_block_end = distribute_blocks(B, alg.k)
+  block_offset = group_offsets(sorted_dates, order, time)
+
+  # Position bounds (in sorted order) for each of the k blocks
+  block_lo = Vector{Int}(undef, alg.k)
+  block_hi = Vector{Int}(undef, alg.k)
+  for i = 1:alg.k
+    start_block = i == 1 ? 1 : chunk_block_end[i-1] + 1
+    block_lo[i] = block_offset[start_block] + 1
+    block_hi[i] = block_offset[chunk_block_end[i]+1]
+  end
+
+  result = TrainTestSplit{Vector{Int}}[]
+
+  for test_blocks in combinations(1:alg.k, alg.n_test_folds)
+    # Test indices: union of all positions in the selected blocks
+    test_positions = Int[]
+    for b in test_blocks
+      append!(test_positions, block_lo[b]:block_hi[b])
+    end
+    test_idx = order[test_positions]
+
+    # Exclusion set: test + purge windows before each test block
+    #                          + embargo windows after each test block
+    excluded = Set{Int}(test_idx)
+    for b in test_blocks
+      for pos = max(1, block_lo[b]-alg.purge):(block_lo[b]-1)
+        push!(excluded, order[pos])
+      end
+      for pos = (block_hi[b]+1):min(N, block_hi[b]+alg.embargo)
+        push!(excluded, order[pos])
+      end
+    end
+
+    train_idx = [i for i = 1:N if i ∉ excluded]
+    isempty(train_idx) && throw(
+      SplitParameterError(
+        "CombinatorialPurgedKFold: a fold has an empty train cohort " *
+        "(purge=$(alg.purge), embargo=$(alg.embargo) too large for the surrounding blocks).",
+      ),
+    )
+
+    push!(result, TrainTestSplit(train_idx, test_idx))
+  end
+
+  return CrossValidationSplit(result)
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DataSplits = "c4daa60e-60e8-4e0a-bcf3-f80a6d479af9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/test/test-combinatorial-purged-kfold.jl
+++ b/test/test-combinatorial-purged-kfold.jl
@@ -1,0 +1,90 @@
+using Test, Random, DataSplits, Dates, Combinatorics
+import DataSplits: SplitParameterError
+
+@testset "CombinatorialPurgedKFold fold count" begin
+  N = 60
+  ts = collect(1:N)
+  X = randn(2, N)
+
+  for (k, ntf) in [(4, 1), (4, 2), (4, 3), (6, 2), (6, 3)]
+    cvs = partition(X, CombinatorialPurgedKFold(k, ntf); time = ts)
+    @test length(folds(cvs)) == binomial(k, ntf)
+  end
+end
+
+@testset "CombinatorialPurgedKFold n_test_folds=1 equivalent to PurgedKFold" begin
+  N = 50
+  ts = collect(1:N)
+  X = randn(2, N)
+
+  cpcv = partition(X, CombinatorialPurgedKFold(5, 1); time = ts)
+  pkf = partition(X, PurgedKFold(5); time = ts)
+
+  cpcv_folds = sort.([(sort(f.train), sort(f.test)) for f in folds(cpcv)])
+  pkf_folds = sort.([(sort(f.train), sort(f.test)) for f in folds(pkf)])
+  @test cpcv_folds == pkf_folds
+end
+
+@testset "CombinatorialPurgedKFold n_test_folds=1 with purge/embargo equivalent to PurgedKFold" begin
+  N = 50
+  ts = collect(1:N)
+  X = randn(2, N)
+
+  cpcv = partition(X, CombinatorialPurgedKFold(5, 1; purge = 2, embargo = 1); time = ts)
+  pkf = partition(X, PurgedKFold(5; purge = 2, embargo = 1); time = ts)
+
+  cpcv_folds = sort.([(sort(f.train), sort(f.test)) for f in folds(cpcv)])
+  pkf_folds = sort.([(sort(f.train), sort(f.test)) for f in folds(pkf)])
+  @test cpcv_folds == pkf_folds
+end
+
+@testset "CombinatorialPurgedKFold each fold is a valid partition" begin
+  N = 60
+  ts = collect(1:N)
+  X = randn(2, N)
+  cvs = partition(X, CombinatorialPurgedKFold(6, 2; purge = 1, embargo = 1); time = ts)
+
+  for f in folds(cvs)
+    @test isempty(intersect(f.train, f.test))
+    @test !isempty(f.train)
+    @test !isempty(f.test)
+    @test all(i -> 1 <= i <= N, f.train)
+    @test all(i -> 1 <= i <= N, f.test)
+  end
+end
+
+@testset "CombinatorialPurgedKFold purge/embargo respect time order" begin
+  N = 60
+  ts = collect(1:N)
+  X = randn(2, N)
+
+  cvs = partition(X, CombinatorialPurgedKFold(6, 1; purge = 3, embargo = 2); time = ts)
+
+  for f in folds(cvs)
+    test_min, test_max = extrema(ts[f.test])
+    train_ts = ts[f.train]
+    @test all(t -> t < test_min - 3 || t > test_max + 2, train_ts)
+  end
+end
+
+@testset "CombinatorialPurgedKFold fallback: timestamps as data" begin
+  ts = collect(1:40)
+  cvs = partition(ts, CombinatorialPurgedKFold(4, 2))
+  @test length(folds(cvs)) == binomial(4, 2)
+  for f in folds(cvs)
+    @test isempty(intersect(f.train, f.test))
+  end
+end
+
+@testset "CombinatorialPurgedKFold parameter validation" begin
+  @test_throws SplitParameterError CombinatorialPurgedKFold(1, 1)
+  @test_throws SplitParameterError CombinatorialPurgedKFold(3, 0)
+  @test_throws SplitParameterError CombinatorialPurgedKFold(3, 3)
+  @test_throws SplitParameterError CombinatorialPurgedKFold(3, 1; purge = -1)
+  @test_throws SplitParameterError CombinatorialPurgedKFold(3, 1; embargo = -1)
+
+  N = 10
+  ts = collect(1:N)
+  X = randn(2, N)
+  @test_throws SplitParameterError partition(X, CombinatorialPurgedKFold(11, 1); time = ts)
+end

--- a/test/test-properties-cv.jl
+++ b/test/test-properties-cv.jl
@@ -382,3 +382,18 @@ end
       every_observation_tests_once(cvs, N)
   end
 end
+
+# ------------------------------------------------------------------
+# CombinatorialPurgedKFold
+# ------------------------------------------------------------------
+
+@testset "CombinatorialPurgedKFold properties" begin
+  @check max_examples = 100 rng = Xoshiro(91) function cpcv_valid_cv(case = kfold_case_gen)
+    N, k = case
+    k = min(k, 6)
+    times = collect(1:N)
+    X = reshape(times, 1, N)
+    cvs = partition(X, CombinatorialPurgedKFold(k, 1); time = times)
+    is_full_partition(cvs, N)
+  end
+end


### PR DESCRIPTION
Combinatorial Purged Cross-Validation (CPCV, de Prado 2018): generates all C(k, n_test) purged train/test pairs, providing a more thorough walk-forward evaluation than standard PurgedKFold for financial time series.