### PR TITLE
Add VenetianBlindsCV

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -144,6 +144,8 @@ for N in [1000, 5000]
   )
   SUITE["crossval"]["PredefinedSplit"][tag] =
     @benchmarkable partition($X, PredefinedSplit($folds))
+  SUITE["crossval"]["VenetianBlindsCV"][tag] =
+    @benchmarkable partition($X, VenetianBlindsCV(5); target = $labels)
 end
 
 # ── Time-series cross-validation ──────────────────────────────────────────────

--- a/docs/src/15-venetian-blinds.md
+++ b/docs/src/15-venetian-blinds.md
@@ -1,0 +1,47 @@
+```@meta
+CurrentModule = DataSplits
+```
+
+# Venetian Blinds CV
+
+**Venetian-blinds cross-validation** sorts samples by target value and assigns
+them to folds in a round-robin pattern: the sample ranked 1st goes to fold 1,
+ranked 2nd to fold 2, …, ranked k-th to fold k, ranked (k+1)-th back to fold 1,
+and so on.
+
+The result resembles the slats of venetian blinds: each fold contains samples
+spread evenly across the full sorted range.
+
+## How it works
+
+```text
+order = sortperm(target)          # rank samples by target value
+for i, idx in enumerate(order):
+    fold_test[mod1(i, k)] ← idx  # round-robin assignment
+```
+
+Each fold receives roughly N/k samples with a systematic spread of values —
+no binning, no randomness (unless `shuffle=true` for tie-breaking).
+
+## VenetianBlindsCV vs. KFold vs. StratifiedKFold
+
+| | [`KFold`](@ref) | [`StratifiedKFold`](@ref) | [`VenetianBlindsCV`](@ref) |
+| --- | --- | --- | --- |
+| Assignment rule | Contiguous blocks | Round-robin within quantile bins | Round-robin on globally sorted order |
+| Binning step | None | Yes (k quantile bins) | None |
+| Requires `target =` | No | Yes | Optional (falls back to data) |
+| Fold spans full value range | No | Approximately | Yes, by construction |
+| Handles continuous targets | n/a | Via quantile bins | Directly |
+
+Use **VenetianBlindsCV** when you have a continuous target and want each fold to
+see the full response range without having to choose a number of quantile bins.
+Common in NIR spectroscopy where samples are ordered by reference value.
+
+## API reference
+
+- [`VenetianBlindsCV`](@ref)
+
+## References
+
+Naes, T.; Isaksson, T.; Fearn, T.; Davies, T. *A User-Friendly Guide to
+Multivariate Calibration and Classification*. NIR Publications, 2002.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -61,6 +61,7 @@ end
 | Group k-fold | [`GroupKFold`](@ref), [`StratifiedGroupKFold`](@ref) |
 | Leave-group-out | [`LeaveOneGroupOut`](@ref), [`LeavePGroupsOut`](@ref) |
 | Time-series CV | [`TimeSeriesSplit`](@ref), [`BlockedCV`](@ref), [`PurgedKFold`](@ref), [`CombinatorialPurgedKFold`](@ref) |
+| Venetian blinds CV | [`VenetianBlindsCV`](@ref) |
 | Resampling CV | [`ShuffleSplit`](@ref), [`StratifiedShuffleSplit`](@ref), [`GroupShuffleSplitCV`](@ref), [`BootstrapSplit`](@ref) |
 | Repeated CV | [`RepeatedKFold`](@ref), [`RepeatedStratifiedKFold`](@ref) |
 | Nested CV | [`NestedCV`](@ref) |

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -36,6 +36,7 @@ include("strategies/NestedCV.jl")
 include("strategies/PurgedKFold.jl")
 include("strategies/CombinatorialPurgedKFold.jl")
 include("strategies/GroupShuffleSplitCV.jl")
+include("strategies/VenetianBlindsCV.jl")
 include("strategies/FieldStrengthSplit.jl")
 include("strategies/SpectralSplit.jl")
 
@@ -81,6 +82,7 @@ export BootstrapSplit
 export NestedCV, NestedFold, innerfolds
 export BlockedCV, PurgedKFold
 export CombinatorialPurgedKFold
+export VenetianBlindsCV
 export RepeatedKFold, RepeatedStratifiedKFold
 
 # Target / time property

--- a/src/strategies/VenetianBlindsCV.jl
+++ b/src/strategies/VenetianBlindsCV.jl
@@ -1,0 +1,98 @@
+"""
+    VenetianBlindsCV(k; shuffle=false) <: AbstractCVStrategy
+
+Venetian-blinds k-fold cross-validation.
+
+Sorts samples by `target` (ascending), then assigns them to folds in a
+round-robin pattern: sample ranked 1st → fold 1, 2nd → fold 2, …, k-th → fold k,
+(k+1)-th → fold 1, and so on.
+
+Unlike [`KFold`](@ref), which assigns *contiguous blocks* to each fold,
+Venetian Blinds distributes the sorted sequence evenly, so every fold covers
+the full value range.  Unlike [`StratifiedKFold`](@ref), it sorts globally
+with no binning step — the assignment is deterministic and does not require
+choosing a number of quantile bins.
+
+# Fields
+- `k::Int`: Number of folds (must be ≥ 2 and ≤ N).
+- `shuffle::Bool`: When `true`, samples with identical target values (ties)
+  are randomly permuted within their tied group before fold assignment, using
+  the `rng` passed to `partition`.  When `false` (default), ties are broken
+  by original sample index (stable sort).
+
+# Notes
+- `target` falls back to `data` when omitted: `partition(y, VenetianBlindsCV(5))`
+  sorts directly by the data vector.
+- For natural index-order (no sorting), pass `target = collect(1:numobs(data))`.
+
+# Examples
+```julia
+# Sort by target value — each fold spans the full response range.
+cvs = partition(X, VenetianBlindsCV(5); target = y)
+
+# Directly on a target vector (no X needed).
+cvs = partition(y, VenetianBlindsCV(5))
+
+# Randomise tie-breaking.
+cvs = partition(X, VenetianBlindsCV(5; shuffle = true); target = y,
+                rng = MersenneTwister(42))
+```
+
+# See also
+[`KFold`](@ref), [`StratifiedKFold`](@ref)
+
+# References
+Naes, T.; Isaksson, T.; Fearn, T.; Davies, T. *A User-Friendly Guide to Multivariate
+Calibration and Classification*. NIR Publications, 2002.
+"""
+struct VenetianBlindsCV <: AbstractCVStrategy
+  k::Int
+  shuffle::Bool
+end
+
+VenetianBlindsCV(k::Integer; shuffle::Bool = false) = VenetianBlindsCV(Int(k), shuffle)
+
+consumes(::VenetianBlindsCV) = (:target,)
+fallback_from_data(::VenetianBlindsCV) = (:target,)
+
+# Shuffle within runs of equal values in target[order] (stable-sort tie groups).
+function _venetian_shuffle_ties!(rng, order::AbstractVector{Int}, target::AbstractVector)
+  n = length(order)
+  i = 1
+  while i <= n
+    j = i
+    while j < n && target[order[j+1]] == target[order[i]]
+      j += 1
+    end
+    j > i && shuffle!(rng, view(order, i:j))
+    i = j + 1
+  end
+end
+
+function _partition(
+  data,
+  alg::VenetianBlindsCV;
+  target,
+  rng = Random.default_rng(),
+  kwargs...,
+)
+  alg.k >= 2 ||
+    throw(SplitParameterError("VenetianBlindsCV requires k ≥ 2, got k=$(alg.k)."))
+  N = numobs(data)
+  alg.k <= N ||
+    throw(SplitParameterError("VenetianBlindsCV requires k ≤ N=$N, got k=$(alg.k)."))
+
+  order = sortperm(target)
+  alg.shuffle && _venetian_shuffle_ties!(rng, order, target)
+
+  fold_test = [Int[] for _ = 1:alg.k]
+  for (i, idx) in enumerate(order)
+    push!(fold_test[mod1(i, alg.k)], idx)
+  end
+
+  result = Vector{TrainTestSplit{Vector{Int}}}(undef, alg.k)
+  for f = 1:alg.k
+    result[f] = TrainTestSplit(setdiff(1:N, fold_test[f]), fold_test[f])
+  end
+  return CrossValidationSplit(result)
+end

--- a/test/test-properties-cv.jl
+++ b/test/test-properties-cv.jl
@@ -397,3 +397,19 @@ end
     is_full_partition(cvs, N)
   end
 end
+
+# ------------------------------------------------------------------
+# VenetianBlindsCV
+# ------------------------------------------------------------------
+
+@testset "VenetianBlindsCV properties" begin
+  @check max_examples = 200 rng = Xoshiro(88) function venetian_blinds_valid_cv(
+    case = kfold_case_gen,
+  )
+    N, k = case
+    X = reshape(collect(1:N), 1, N)
+    target = collect(1.0:N)
+    cvs = partition(X, VenetianBlindsCV(k); target = target)
+    length(cvs) == k && is_full_partition(cvs, N) && every_observation_tests_once(cvs, N)
+  end
+end

--- a/test/test-venetian-blinds-cv.jl
+++ b/test/test-venetian-blinds-cv.jl
@@ -1,0 +1,87 @@
+using Test
+using DataSplits
+using Random
+import DataSplits: SplitParameterError
+
+@testset "VenetianBlindsCV basic fold count" begin
+  y = collect(1.0:50.0)
+  cvs = partition(y, VenetianBlindsCV(5))
+  @test length(folds(cvs)) == 5
+end
+
+@testset "VenetianBlindsCV every observation tested once" begin
+  y = collect(1.0:50.0)
+  for k in [2, 5, 10]
+    cvs = partition(y, VenetianBlindsCV(k))
+    test_counts = zeros(Int, 50)
+    for fold in cvs
+      for i in testindices(fold)
+        test_counts[i] += 1
+      end
+    end
+    @test all(==(1), test_counts)
+  end
+end
+
+@testset "VenetianBlindsCV deterministic fold assignment" begin
+  # With target = 1:N and k=5, fold f gets indices f, f+5, f+10, ...
+  N = 20
+  y = collect(1:N)
+  cvs = partition(y, VenetianBlindsCV(5))
+  for f = 1:5
+    expected_test = Set(f:5:N)
+    @test Set(testindices(cvs[f])) == expected_test
+  end
+end
+
+@testset "VenetianBlindsCV sorts by target" begin
+  # target = [5,1,3,2,4] → sorted order [2,4,3,5,1]
+  # With k=5: fold 1 gets rank-1 sample = index 2
+  y = [5, 1, 3, 2, 4]
+  cvs = partition(y, VenetianBlindsCV(5))
+  # sorted indices: y[2]=1, y[4]=2, y[3]=3, y[5]=4, y[1]=5
+  @test testindices(cvs[1]) == [2]
+  @test testindices(cvs[2]) == [4]
+  @test testindices(cvs[3]) == [3]
+  @test testindices(cvs[4]) == [5]
+  @test testindices(cvs[5]) == [1]
+end
+
+@testset "VenetianBlindsCV fallback to data" begin
+  y = collect(1.0:20.0)
+  cvs = partition(y, VenetianBlindsCV(4))
+  @test length(folds(cvs)) == 4
+end
+
+@testset "VenetianBlindsCV shuffle reproducible" begin
+  y = [1, 1, 1, 2, 2, 2, 3, 3, 3]
+  cvs1 = partition(y, VenetianBlindsCV(3; shuffle = true); rng = MersenneTwister(42))
+  cvs2 = partition(y, VenetianBlindsCV(3; shuffle = true); rng = MersenneTwister(42))
+  cvs3 = partition(y, VenetianBlindsCV(3; shuffle = true); rng = MersenneTwister(99))
+  @test testindices(cvs1[1]) == testindices(cvs2[1])
+  @test testindices(cvs1[1]) != testindices(cvs3[1]) || true  # different seeds may differ
+end
+
+@testset "VenetianBlindsCV fold sizes balanced" begin
+  y = collect(1.0:50.0)
+  cvs = partition(y, VenetianBlindsCV(5))
+  sizes = [length(testindices(f)) for f in cvs]
+  @test maximum(sizes) - minimum(sizes) <= 1
+end
+
+@testset "VenetianBlindsCV errors" begin
+  y = collect(1.0:10.0)
+  @test_throws SplitParameterError partition(y, VenetianBlindsCV(1))
+  @test_throws SplitParameterError partition(y, VenetianBlindsCV(11))
+end
+
+@testset "VenetianBlindsCV differs from KFold" begin
+  # KFold gives contiguous blocks; VenetianBlinds interleaves
+  N = 20
+  y = collect(1.0:N)
+  cvs_vb = partition(y, VenetianBlindsCV(4))
+  cvs_kf = partition(y, KFold(4))
+  # VenetianBlinds fold 1 should get {1, 5, 9, 13, 17}, not {1..5}
+  @test Set(testindices(cvs_vb[1])) != Set(testindices(cvs_kf[1]))
+  @test Set(testindices(cvs_vb[1])) == Set(1:4:N)
+end


### PR DESCRIPTION
Round-robin fold assignment over sorted-by-target samples. Guarantees a perfectly uniform spread of the target range across all folds without binning, widely used in NIR spectroscopy calibration.