### PR TITLE
Add OnionSplit and XYOnionSplit

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -60,6 +60,10 @@ for N in [200, 500, 1000]
     @benchmarkable partition($X, DuplexSplit(); train = 0.8, test = 0.2)
   SUITE["distance"]["LazyDuplexSplit"][tag] =
     @benchmarkable partition($X, LazyDuplexSplit(); train = 0.8, test = 0.2)
+  SUITE["distance"]["XYOnionSplit"][tag] =
+    @benchmarkable partition($X, XYOnionSplit(); train = 0.8, test = 0.2)
+  SUITE["distance"]["OnionSplit"][tag] =
+    @benchmarkable partition($X, OnionSplit(); train = 0.8, test = 0.2)
 end
 
 # ── Simple train/test splits (O(N)) ──────────────────────────────────────────

--- a/docs/src/13-onion.md
+++ b/docs/src/13-onion.md
@@ -1,0 +1,140 @@
+```@meta
+CurrentModule = DataSplits
+```
+
+# Onion and XYOnion
+
+The **Onion** family of algorithms splits a dataset into training and test sets by
+peeling concentric shells — like the layers of an onion — from the data cloud.  The
+outer layers, which contain the most "extreme" samples furthest from the centroid, go
+to the training set; the next-outermost samples form the test set; the remaining core
+is assigned randomly in the requested proportion.
+
+There are two variants:
+
+- [`OnionSplit`](@ref) — uses only `X` (feature matrix). The training set covers the
+  boundary of the data space; the test set sits just inside it.
+- [`XYOnionSplit`](@ref) — uses both `X` and `y` (target). Distance from the centroid
+  is measured jointly in X–y space (the same normalised SPXY distance used by
+  [`SPXYSplit`](@ref)), so the outer layers cover both feature and response diversity.
+
+Both share the same layered loop and accept an optional Mahalanobis metric.
+
+## How it works
+
+For a dataset with N samples and a requested `fraction` for training:
+
+1. In each of `n_layers` iterations, select roughly `10 % × fraction × remaining`
+   samples as the **outermost** (farthest from the centroid) and assign them to
+   **train**; then select the next `10 % × (1−fraction) × remaining` samples and
+   assign them to **test**.
+2. Repeat until all layers are peeled.
+3. Assign the remaining **core** samples randomly in the requested proportion.
+
+The outer-layer selection uses the *distslct* algorithm (Gallagher et al. 2003):
+
+- When the number of samples to select is **≤ F** (number of features): use
+  iterative orthogonalisation.  Pick the sample with the largest distance from the
+  centroid, project it out of the working matrix (Gram–Schmidt step), and repeat.
+- When the number to select **> F**: bootstrap F samples with the orthogonalisation
+  method, then extend greedily by cumulative SPXY-style distance — the next sample
+  maximises the sum of distances to all already-selected samples.
+
+### Approximate split sizes
+
+Because counts are computed with `round` in each layer, the final number of training
+and test samples may differ from the exact requested values by a few samples.  This is
+by design — the layered structure takes priority over exact counts.
+
+## Onion vs. XYOnion
+
+| | [`OnionSplit`](@ref) | [`XYOnionSplit`](@ref) |
+| --- | --- | --- |
+| Requires `target =` | No | Yes |
+| Distance space | X only | X + y (normalised SPXY) |
+| Good for | Unsupervised coverage | Regression with known y |
+| Same as... | XYOnion with y = 0 | — |
+
+Use **`OnionSplit`** when you do not have a target variable, or when covering the
+feature space is the primary concern (e.g. spectroscopic calibration, geospatial
+sampling, molecular diversity).
+
+Use **`XYOnionSplit`** when you have a regression target and want the outer training
+layers to cover the response range as well as the feature space — similar reasoning to
+preferring SPXY over Kennard–Stone.
+
+## Onion vs. Kennard–Stone
+
+Both algorithms select training samples that cover the boundary of the data space, but
+they do it differently:
+
+- **Kennard–Stone** is a global greedy algorithm: every new sample maximises the
+  minimum distance to all previously selected samples.  It guarantees exact split
+  sizes and is fully deterministic.
+- **Onion** is a layered algorithm: it peels shells of a fixed thickness (10 % of the
+  remaining pool) and assigns the remainder randomly.  This produces a more balanced
+  distribution across the data space (training samples are not concentrated only at
+  the extremes) at the cost of approximate cohort sizes and one random step.
+
+For large `n_layers` the onion layers become thin and the result approaches
+Kennard–Stone.  For `n_layers = 1` almost all samples go through the random step.
+
+## Usage
+
+### OnionSplit — X only
+
+```julia
+using DataSplits
+
+res = partition(X, OnionSplit(); train = 70, test = 30)
+X_train, X_test = splitdata(res, X)
+```
+
+### XYOnionSplit — X and y
+
+```julia
+using DataSplits
+
+res = partition(X, XYOnionSplit(); target = y, train = 70, test = 30)
+X_train, X_test = splitdata(res, X)
+y_train, y_test = splitdata(res, y)
+```
+
+### Mahalanobis distance
+
+Pass `metric_X = nothing` to compute Mahalanobis distance from the sample covariance
+at split time.  This accounts for feature correlations and is recommended when
+variables have very different variances or are highly collinear.
+
+```julia
+res = partition(X, OnionSplit(; metric_X = nothing); train = 70, test = 30)
+res = partition(X, XYOnionSplit(; metric_X = nothing); target = y, train = 70, test = 30)
+```
+
+### Controlling the number of layers
+
+The default of 3 layers works well for most datasets.  For small datasets (N < 30)
+consider increasing `n_layers` so that each layer contains at least a few samples:
+
+```julia
+res = partition(X, OnionSplit(; n_layers = 5); train = 70, test = 30)
+```
+
+## API reference
+
+- [`OnionSplit`](@ref)
+- [`XYOnionSplit`](@ref)
+
+## References
+
+Ezenarro, J. et al. XYOnion: A Layer-Based Method for Splitting Datasets into
+Calibration and Validation Subsets. *Analytica Chimica Acta* 2025, 344229.
+<https://doi.org/10.1016/j.aca.2025.344229>.
+
+Gallagher, N.B.; O'Sullivan, D. *Selection of Representative Learning and Test Sets
+Using the Onion Method.* Eigenvector Research Technical Report (2022).
+<https://eigenvector.com/wp-content/uploads/2022/10/Onion_SampleSelection.pdf>.
+
+Gallagher, N.B.; Shaver, J.M.; Martin, E.B.; Morris, J.; Wise, B.M.; Windig, W.
+Curve resolution for images with applications to TOF-SIMS and Raman.
+*Chemometrics and Intelligent Laboratory Systems* 2003, 77(1), 105–117.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,6 +48,7 @@ end
 | --- | --- |
 | Cover feature space (maximin) | [`KennardStoneSplit`](@ref) / [`LazyKennardStoneSplit`](@ref) |
 | Simultaneous train+test coverage (Duplex) | [`DuplexSplit`](@ref), [`LazyDuplexSplit`](@ref) |
+| Onion split | [`XYOnionSplit`](@ref), [`OnionSplit`](@ref) |
 | Cover features + target jointly | [`SPXYSplit`](@ref), [`MDKSSplit`](@ref) |
 | Field-strength split | [`FieldStrengthSplit`](@ref) |
 | Spectral cluster split | [`SpectralSplit`](@ref) |

--- a/src/DataSplits.jl
+++ b/src/DataSplits.jl
@@ -7,6 +7,8 @@ include("strategies/random.jl")
 include("strategies/LazyKennardStone.jl")
 include("strategies/Duplex.jl")
 include("strategies/KennardStone.jl")
+include("strategies/XYOnion.jl")
+include("strategies/Onion.jl")
 include("strategies/SPXY.jl")
 include("strategies/LazySPXY.jl")
 include("strategies/MoraisLimaMartinSplit.jl")
@@ -61,6 +63,8 @@ export DuplexSplit, LazyDuplexSplit
 export MoraisLimaMartinSplit
 export SPXYSplit, MDKSSplit
 export LazySPXYSplit, LazyMDKSSplit
+export XYOnionSplit
+export OnionSplit
 export OptiSimSplit
 export LazyOptiSimSplit
 export MinimumDissimilaritySplit, LazyMinimumDissimilaritySplit

--- a/src/strategies/Onion.jl
+++ b/src/strategies/Onion.jl
@@ -1,0 +1,71 @@
+"""
+    OnionSplit <: AbstractSplitStrategy
+
+Onion algorithm for train/test splitting.
+
+Selects representative calibration and test samples by iteratively peeling
+onion-like layers based on Euclidean distance from the centroid of `X`.
+The outer layers (farthest from the centroid) go to the training set; the
+next-outermost to the test set; remaining samples are assigned randomly in
+the requested proportion.
+
+This is the X-only counterpart of [`XYOnionSplit`](@ref): target values are not
+used.  The split sizes are approximate — rounding in each layer means the final
+train/test counts may differ slightly from the requested percentages.
+
+# Fields
+- `n_layers::Int`: Number of onion layers (default: `3`)
+- `metric_X::Union{Nothing,Distances.SemiMetric}`: Distance metric for `X`.
+  `nothing` computes Mahalanobis distance via eigendecomposition of the data
+  covariance at split time.  `Euclidean()` (default) uses standard Euclidean
+  distance.
+
+# Examples
+```julia
+res = partition(X, OnionSplit(); train = 70, test = 30)
+res = partition(X, OnionSplit(; metric_X = nothing); train = 70, test = 30)
+X_train, X_test = splitdata(res, X)
+```
+
+# References
+Gallagher, N.B.; O'Sullivan, D. *Selection of Representative Learning and Test
+Sets Using the Onion Method.* Eigenvector Research Technical Report (2022).
+https://eigenvector.com/wp-content/uploads/2022/10/Onion_SampleSelection.pdf
+
+# See also
+[`XYOnionSplit`](@ref) — joint X–y variant of this algorithm.
+"""
+struct OnionSplit <: AbstractSplitStrategy
+  n_layers::Int
+  metric_X::Union{Nothing,Distances.SemiMetric}
+end
+
+OnionSplit(; n_layers::Int = 3, metric_X = Euclidean()) = OnionSplit(n_layers, metric_X)
+
+consumes(::OnionSplit) = (:data,)
+fallback_from_data(::OnionSplit) = ()
+
+function _partition(
+  X,
+  s::OnionSplit;
+  n_train,
+  n_test,
+  rng = Random.default_rng(),
+  kwargs...,
+)
+  Xf = float.(X)
+  Xw = s.metric_X === nothing ? _xyonion_whiten(Xf) : Xf
+  train_idx, test_idx = _onion_partition!(Xw, nothing, n_train, n_test, s.n_layers, rng)
+  return TrainTestSplit(train_idx, test_idx)
+end
+
+function _partition(
+  X::AbstractVector{<:AbstractVector},
+  s::OnionSplit;
+  n_train,
+  n_test,
+  rng = Random.default_rng(),
+  kwargs...,
+)
+  _partition(stack(X), s; n_train, n_test, rng)
+end

--- a/src/strategies/XYOnion.jl
+++ b/src/strategies/XYOnion.jl
@@ -1,0 +1,395 @@
+using Distances, LinearAlgebra, Statistics
+
+"""
+    XYOnionSplit <: AbstractSplitStrategy
+
+XY-Onion algorithm for train/test splitting.
+
+Combines the SPXY joint X–y distance with the Onion layered-sampling strategy.
+The dataset is peeled in `n_layers` concentric shells: in each layer, the outermost
+samples (farthest from the centroid in the combined X–y space) are selected for the
+training set and the next-outermost for the test set.  Remaining samples after all
+layers are assigned randomly in the requested proportion.
+
+The split sizes are approximate: rounding in each layer means the final train/test
+counts may differ by a few samples from the requested percentages.
+
+# Fields
+- `n_layers::Int`: Number of onion layers (default: `3`)
+- `metric_X::Union{Nothing,Distances.SemiMetric}`: Distance metric for `X`.
+  `nothing` computes Mahalanobis distance via eigendecomposition of the data
+  covariance at split time (equivalent to the `mahalanobis=1` flag in the original
+  MATLAB implementation).  `Euclidean()` (default) uses standard Euclidean distance.
+
+# Examples
+```julia
+res = partition(X, XYOnionSplit(); target = y, train = 70, test = 30)
+res = partition(X, XYOnionSplit(; metric_X = nothing); target = y, train = 70, test = 30)
+X_train, X_test = splitdata(res, X)
+```
+
+# References
+Ezenarro, J. et al. (2025). *Analytica Chimica Acta*, 344229.
+https://doi.org/10.1016/j.aca.2025.344229
+
+# See also
+[`OnionSplit`](@ref) — X-only variant of this algorithm.
+"""
+struct XYOnionSplit <: AbstractSplitStrategy
+  n_layers::Int
+  metric_X::Union{Nothing,Distances.SemiMetric}
+end
+
+XYOnionSplit(; n_layers::Int = 3, metric_X = Euclidean()) = XYOnionSplit(n_layers, metric_X)
+
+consumes(::XYOnionSplit) = (:data, :target)
+fallback_from_data(::XYOnionSplit) = ()
+
+# ---------------------------------------------------------------------------
+# Shared infrastructure used by both OnionSplit and XYOnionSplit
+# ---------------------------------------------------------------------------
+
+# Whiten X (F×N) so Euclidean distances equal Mahalanobis distances in the original space.
+function _xyonion_whiten(X::AbstractMatrix)
+  C = cov(X; dims = 2)
+  F = eigen(Symmetric(C))
+  W = F.vectors * Diagonal(1 ./ sqrt.(max.(F.values, eps()))) * F.vectors'
+  return W * X
+end
+
+# Allocation-free argmax of ‖X[:,j]‖²  (j ∈ 1:last).
+function _onion_stds_argmax(X::AbstractMatrix, last::Int)
+  F = size(X, 1)
+  best = -Inf
+  k = 1
+  @inbounds for j = 1:last
+    nX = 0.0
+    @simd for f = 1:F
+      nX = muladd(X[f, j], X[f, j], nX)
+    end
+    if nX > best
+      best = nX
+      k = j
+    end
+  end
+  return k
+end
+
+# Allocation-free argmax of ‖X[:,j]‖²/max_nX + y[j]²/max_nY  (j ∈ 1:last).
+# norms_sq is a pre-allocated scratch buffer of length ≥ last.
+function _onion_stds_argmax_xy(
+  X::AbstractMatrix,
+  y::AbstractVector,
+  last::Int,
+  norms_sq::AbstractVector,
+)
+  F = size(X, 1)
+  max_nX = 0.0
+  max_nY = 0.0
+  @inbounds for j = 1:last
+    nX = 0.0
+    @simd for f = 1:F
+      nX = muladd(X[f, j], X[f, j], nX)
+    end
+    norms_sq[j] = nX
+    max_nX = max(max_nX, nX)
+    max_nY = max(max_nY, y[j]^2)
+  end
+  inv_nX = max_nX > 0 ? 1.0 / max_nX : 0.0
+  inv_nY = max_nY > 0 ? 1.0 / max_nY : 0.0
+  best = -Inf
+  k = 1
+  @inbounds for j = 1:last
+    s = muladd(y[j]^2, inv_nY, norms_sq[j] * inv_nX)
+    if s > best
+      best = s
+      k = j
+    end
+  end
+  return k
+end
+
+"""
+    _onion_stdsslct(X, y, nosamps) -> Vector{Int}
+
+Select `nosamps` outer samples from mean-centred `X` (F×M) using the
+norm-based iterative orthogonalisation variant of the distslct algorithm.
+
+`y` is either an `AbstractVector` (XY-Onion: both X and y distances contribute
+to sample scoring) or `nothing` (plain Onion: X distance only).
+
+Each iteration: pick the sample with the largest score, swap it to the last active
+position (in-place), orthogonalise the remaining columns against it via BLAS rank-1
+update, then shrink the active window.
+"""
+function _onion_stdsslct(X::AbstractMatrix, y::AbstractVector, nosamps::Int)
+  F, M = size(X)
+  Xw = float.(X)
+  yw = float.(y)
+  idx = collect(1:M)
+  subset = Vector{Int}(undef, nosamps)
+  proj = Vector{Float64}(undef, M)
+  norms_sq = Vector{Float64}(undef, M)
+  tmp_col = Vector{Float64}(undef, F)
+
+  for i = 1:nosamps
+    last = M - i + 1
+    k = _onion_stds_argmax_xy(Xw, yw, last, norms_sq)
+    subset[i] = idx[k]
+
+    if k != last
+      copyto!(tmp_col, view(Xw, :, k))
+      copyto!(view(Xw, :, k), view(Xw, :, last))
+      copyto!(view(Xw, :, last), tmp_col)
+      yw[k], yw[last] = yw[last], yw[k]
+      idx[k], idx[last] = idx[last], idx[k]
+    end
+
+    if last > 1
+      rx0 = view(Xw, :, last)
+      nr2 = dot(rx0, rx0)
+      if nr2 > 0
+        Xrem = view(Xw, :, 1:(last-1))
+        pv = view(proj, 1:(last-1))
+        BLAS.gemv!('T', 1.0 / nr2, Xrem, rx0, 0.0, pv)
+        BLAS.ger!(-1.0, rx0, pv, Xrem)
+      end
+      yw[1:(last-1)] .-= yw[last]
+    end
+  end
+  return subset
+end
+
+function _onion_stdsslct(X::AbstractMatrix, ::Nothing, nosamps::Int)
+  F, M = size(X)
+  Xw = float.(X)
+  idx = collect(1:M)
+  subset = Vector{Int}(undef, nosamps)
+  proj = Vector{Float64}(undef, M)
+  tmp_col = Vector{Float64}(undef, F)
+
+  for i = 1:nosamps
+    last = M - i + 1
+    k = _onion_stds_argmax(Xw, last)
+    subset[i] = idx[k]
+
+    if k != last
+      copyto!(tmp_col, view(Xw, :, k))
+      copyto!(view(Xw, :, k), view(Xw, :, last))
+      copyto!(view(Xw, :, last), tmp_col)
+      idx[k], idx[last] = idx[last], idx[k]
+    end
+
+    if last > 1
+      rx0 = view(Xw, :, last)
+      nr2 = dot(rx0, rx0)
+      if nr2 > 0
+        Xrem = view(Xw, :, 1:(last-1))
+        pv = view(proj, 1:(last-1))
+        BLAS.gemv!('T', 1.0 / nr2, Xrem, rx0, 0.0, pv)
+        BLAS.ger!(-1.0, rx0, pv, Xrem)
+      end
+    end
+  end
+  return subset
+end
+
+# Add Euclidean distances from sample `k` to `dX` (and optionally `dY`) in-place.
+function _onion_add_dists!(
+  dX::AbstractVector,
+  dY::AbstractVector,
+  Xc::AbstractMatrix,
+  yc::AbstractVector,
+  col_norms_sq::AbstractVector,
+  dots::AbstractVector,
+  k::Int,
+)
+  xsel = view(Xc, :, k)
+  nsel_sq = dot(xsel, xsel)
+  BLAS.gemv!('T', 1.0, Xc, xsel, 0.0, dots)
+  @inbounds for j in eachindex(dX)
+    dX[j] += sqrt(max(0.0, col_norms_sq[j] - 2 * dots[j] + nsel_sq))
+  end
+  ysel = yc[k]
+  @inbounds for j in eachindex(dY)
+    dY[j] += abs(yc[j] - ysel)
+  end
+end
+
+function _onion_add_dists!(
+  dX::AbstractVector,
+  ::Nothing,
+  Xc::AbstractMatrix,
+  ::Nothing,
+  col_norms_sq::AbstractVector,
+  dots::AbstractVector,
+  k::Int,
+)
+  xsel = view(Xc, :, k)
+  nsel_sq = dot(xsel, xsel)
+  BLAS.gemv!('T', 1.0, Xc, xsel, 0.0, dots)
+  @inbounds for j in eachindex(dX)
+    dX[j] += sqrt(max(0.0, col_norms_sq[j] - 2 * dots[j] + nsel_sq))
+  end
+end
+
+# Allocation-free argmax of dX[j]/max_dX + dY[j]/max_dY.
+function _onion_dist_argmax(dX::AbstractVector, dY::AbstractVector)
+  max_dX = maximum(dX)
+  max_dY = maximum(dY)
+  inv_dX = max_dX > 0 ? 1.0 / max_dX : 0.0
+  inv_dY = max_dY > 0 ? 1.0 / max_dY : 0.0
+  best = -Inf
+  k = 1
+  @inbounds for j in eachindex(dX)
+    s = muladd(dY[j], inv_dY, dX[j] * inv_dX)
+    if s > best
+      best = s
+      k = j
+    end
+  end
+  return k
+end
+
+_onion_dist_argmax(dX::AbstractVector, ::Nothing) = argmax(dX)
+
+"""
+    _onion_distslct(X, y, nosamps) -> Vector{Int}
+
+Select `nosamps` outer samples from `X` (F×M).
+
+`y` is either an `AbstractVector` (XY-Onion) or `nothing` (plain Onion).
+Mean-centres the inputs, then dispatches to `_onion_stdsslct` when `nosamps ≤ F`,
+otherwise bootstraps F samples via `_onion_stdsslct` and expands greedily using
+cumulative distance, zeroing selected positions before each argmax to prevent
+reselection.
+"""
+function _onion_distslct(X::AbstractMatrix, y, nosamps::Int)
+  nosamps == 0 && return Int[]
+  F, M = size(X)
+  nosamps = min(nosamps, M)
+
+  Xc = X .- mean(X; dims = 2)
+  yc = y === nothing ? nothing : y .- mean(y)
+
+  nosamps <= F && return _onion_stdsslct(Xc, yc, nosamps)
+
+  isel = Vector{Int}(undef, nosamps)
+  isel[1:F] = _onion_stdsslct(Xc, yc, F)
+
+  selected = falses(M)
+  selected[isel[1:F]] .= true
+
+  col_norms_sq = vec(sum(abs2, Xc; dims = 1))
+  dX = zeros(M)
+  dY = yc === nothing ? nothing : zeros(M)
+  dots = Vector{Float64}(undef, M)
+
+  for ii = 1:F
+    _onion_add_dists!(dX, dY, Xc, yc, col_norms_sq, dots, isel[ii])
+  end
+  dX[selected] .= 0.0
+  dY !== nothing && (dY[selected] .= 0.0)
+
+  for ii = (F+1):nosamps
+    isel[ii] = _onion_dist_argmax(dX, dY)
+    selected[isel[ii]] = true
+    dX[isel[ii]] = 0.0
+    dY !== nothing && (dY[isel[ii]] = 0.0)
+    if ii < nosamps
+      _onion_add_dists!(dX, dY, Xc, yc, col_norms_sq, dots, isel[ii])
+      dX[selected] .= 0.0
+      dY !== nothing && (dY[selected] .= 0.0)
+    end
+  end
+
+  return isel
+end
+
+# ---------------------------------------------------------------------------
+# Shared _partition loop body
+# ---------------------------------------------------------------------------
+
+function _onion_partition!(
+  Xw::AbstractMatrix,
+  yf,   # AbstractVector or nothing
+  n_train::Int,
+  n_test::Int,
+  n_layers::Int,
+  rng,
+)
+  N = size(Xw, 2)
+  fraction = n_train / (n_train + n_test)
+  loopfrac = 0.1
+
+  i0 = collect(1:N)
+  train_idx = sizehint!(Int[], n_train)
+  test_idx = sizehint!(Int[], n_test)
+
+  for _ = 1:n_layers
+    m0 = length(i0)
+    m0 == 0 && break
+
+    ncal = round(Int, loopfrac * m0 * fraction)
+    if ncal > 0
+      yi = yf === nothing ? nothing : yf[i0]
+      isel = _onion_distslct(Xw[:, i0], yi, min(m0, ncal))
+      append!(train_idx, i0[isel])
+      deleteat!(i0, sort(isel))
+    end
+
+    m0 = length(i0)
+    m0 == 0 && break
+
+    ntest = round(Int, loopfrac * m0 * (1 - fraction))
+    if ntest > 0
+      yi = yf === nothing ? nothing : yf[i0]
+      isel = _onion_distslct(Xw[:, i0], yi, min(m0, ntest))
+      append!(test_idx, i0[isel])
+      deleteat!(i0, sort(isel))
+    end
+  end
+
+  m0 = length(i0)
+  if m0 > 0
+    nc = ceil(Int, m0 * fraction)
+    labels = shuffle(rng, [trues(nc); falses(m0 - nc)])
+    for (j, to_train) in enumerate(labels)
+      push!(to_train ? train_idx : test_idx, i0[j])
+    end
+  end
+
+  return train_idx, test_idx
+end
+
+# ---------------------------------------------------------------------------
+# XYOnionSplit _partition
+# ---------------------------------------------------------------------------
+
+function _partition(
+  X,
+  s::XYOnionSplit;
+  target,
+  n_train,
+  n_test,
+  rng = Random.default_rng(),
+  kwargs...,
+)
+  Xf = float.(X)
+  Xw = s.metric_X === nothing ? _xyonion_whiten(Xf) : Xf
+  yf = float.(target)
+  train_idx, test_idx = _onion_partition!(Xw, yf, n_train, n_test, s.n_layers, rng)
+  return TrainTestSplit(train_idx, test_idx)
+end
+
+function _partition(
+  X::AbstractVector{<:AbstractVector},
+  s::XYOnionSplit;
+  target,
+  n_train,
+  n_test,
+  rng = Random.default_rng(),
+  kwargs...,
+)
+  _partition(stack(X), s; target, n_train, n_test, rng)
+end

--- a/test/test-onion.jl
+++ b/test/test-onion.jl
@@ -1,0 +1,82 @@
+using Test
+using DataSplits
+using Distances
+using Random
+import DataSplits: SplitInputError
+
+rng_data = MersenneTwister(42)
+X50 = randn(rng_data, 4, 50)
+
+@testset "OnionSplit basic properties" begin
+  res = partition(X50, OnionSplit(); train = 70, test = 30, rng = MersenneTwister(1))
+  train_idx, test_idx = res.train, res.test
+
+  @test length(train_idx) + length(test_idx) == 50
+  @test isempty(intersect(Set(train_idx), Set(test_idx)))
+  @test Set(vcat(train_idx, test_idx)) == Set(1:50)
+  @test !isempty(train_idx)
+  @test !isempty(test_idx)
+end
+
+@testset "OnionSplit Mahalanobis" begin
+  res = partition(
+    X50,
+    OnionSplit(; metric_X = nothing);
+    train = 70,
+    test = 30,
+    rng = MersenneTwister(1),
+  )
+  all_idx = vcat(res.train, res.test)
+
+  @test length(all_idx) == 50
+  @test Set(all_idx) == Set(1:50)
+end
+
+@testset "OnionSplit n_layers parameter" begin
+  for nl in (1, 5)
+    res = partition(
+      X50,
+      OnionSplit(; n_layers = nl);
+      train = 70,
+      test = 30,
+      rng = MersenneTwister(1),
+    )
+    @test length(res.train) + length(res.test) == 50
+    @test Set(vcat(res.train, res.test)) == Set(1:50)
+  end
+end
+
+@testset "OnionSplit does not require target" begin
+  @test_nowarn partition(X50, OnionSplit(); train = 70, test = 30)
+end
+
+@testset "OnionSplit target keyword rejected" begin
+  y = randn(50)
+  @test_throws SplitInputError partition(
+    X50,
+    OnionSplit();
+    target = y,
+    train = 70,
+    test = 30,
+  )
+end
+
+@testset "OnionSplit vector-of-vectors input" begin
+  Xvov = [X50[:, i] for i = 1:50]
+  res = partition(Xvov, OnionSplit(); train = 70, test = 30, rng = MersenneTwister(1))
+  @test length(res.train) + length(res.test) == 50
+  @test Set(vcat(res.train, res.test)) == Set(1:50)
+end
+
+@testset "OnionSplit nosamps > F (SPXY extension path)" begin
+  X3 = randn(MersenneTwister(7), 3, 50)
+  res = partition(
+    X3,
+    OnionSplit(; n_layers = 5);
+    train = 70,
+    test = 30,
+    rng = MersenneTwister(1),
+  )
+  @test length(res.train) + length(res.test) == 50
+  @test Set(vcat(res.train, res.test)) == Set(1:50)
+end

--- a/test/test-properties.jl
+++ b/test/test-properties.jl
@@ -259,6 +259,33 @@ for (label, runner) in TARGET_SPLITS
 end
 
 # ------------------------------------------------------------------
+# OnionSplit — approximate sizes (rounding per layer), only check coverage
+# ------------------------------------------------------------------
+
+@testset "OnionSplit partition invariants" begin
+  @check max_examples = 200 rng = Xoshiro(7) function onion_valid_partition(
+    case = algo_sizes_gen,
+  )
+    N, n_train, n_test = case
+    X = reshape(collect(1.0:N), 1, N)
+    result = partition(X, OnionSplit(); train = n_train, test = n_test)
+    is_full_partition(result, N) && cohorts_are_complements(result, N)
+  end
+end
+
+@testset "XYOnionSplit partition invariants" begin
+  @check max_examples = 200 rng = Xoshiro(8) function xyonion_valid_partition(
+    case = algo_sizes_gen,
+  )
+    N, n_train, n_test = case
+    X = reshape(collect(1.0:N), 1, N)
+    y = collect(1.0:N)
+    result = partition(X, XYOnionSplit(); target = y, train = n_train, test = n_test)
+    is_full_partition(result, N) && cohorts_are_complements(result, N)
+  end
+end
+
+# ------------------------------------------------------------------
 # TargetProperty — unique direction property (ordering of train vs test)
 # ------------------------------------------------------------------
 

--- a/test/test-xyonion.jl
+++ b/test/test-xyonion.jl
@@ -1,0 +1,103 @@
+using Test
+using DataSplits
+using Distances
+using Statistics
+using Random
+import DataSplits: SplitInputError
+
+# Reproducible dataset: 50 samples, 4 features, 1 target
+rng_data = MersenneTwister(42)
+X50 = randn(rng_data, 4, 50)
+y50 = randn(rng_data, 50)
+
+@testset "XYOnion basic properties" begin
+  res = partition(
+    X50,
+    XYOnionSplit();
+    target = y50,
+    train = 70,
+    test = 30,
+    rng = MersenneTwister(1),
+  )
+  train_idx, test_idx = res.train, res.test
+
+  @test length(train_idx) + length(test_idx) == 50
+  @test isempty(intersect(Set(train_idx), Set(test_idx)))
+  @test Set(vcat(train_idx, test_idx)) == Set(1:50)
+  @test !isempty(train_idx)
+  @test !isempty(test_idx)
+end
+
+@testset "XYOnion Mahalanobis" begin
+  res = partition(
+    X50,
+    XYOnionSplit(; metric_X = nothing);
+    target = y50,
+    train = 70,
+    test = 30,
+    rng = MersenneTwister(1),
+  )
+  train_idx, test_idx = res.train, res.test
+
+  @test length(train_idx) + length(test_idx) == 50
+  @test isempty(intersect(Set(train_idx), Set(test_idx)))
+  @test Set(vcat(train_idx, test_idx)) == Set(1:50)
+end
+
+@testset "XYOnion n_layers parameter" begin
+  res1 = partition(
+    X50,
+    XYOnionSplit(; n_layers = 1);
+    target = y50,
+    train = 70,
+    test = 30,
+    rng = MersenneTwister(1),
+  )
+  res5 = partition(
+    X50,
+    XYOnionSplit(; n_layers = 5);
+    target = y50,
+    train = 70,
+    test = 30,
+    rng = MersenneTwister(1),
+  )
+
+  for res in (res1, res5)
+    @test length(res.train) + length(res.test) == 50
+    @test Set(vcat(res.train, res.test)) == Set(1:50)
+  end
+end
+
+@testset "XYOnion requires target" begin
+  @test_throws SplitInputError partition(X50, XYOnionSplit(); train = 70, test = 30)
+end
+
+@testset "XYOnion vector-of-vectors input" begin
+  Xvov = [X50[:, i] for i = 1:50]
+  res = partition(
+    Xvov,
+    XYOnionSplit();
+    target = y50,
+    train = 70,
+    test = 30,
+    rng = MersenneTwister(1),
+  )
+  @test length(res.train) + length(res.test) == 50
+  @test Set(vcat(res.train, res.test)) == Set(1:50)
+end
+
+@testset "XYOnion nosamps > F (SPXY extension path)" begin
+  # 3 features, 50 samples → ncalloop can exceed F=3
+  X3 = randn(MersenneTwister(7), 3, 50)
+  y3 = randn(MersenneTwister(8), 50)
+  res = partition(
+    X3,
+    XYOnionSplit(; n_layers = 5);
+    target = y3,
+    train = 70,
+    test = 30,
+    rng = MersenneTwister(1),
+  )
+  @test length(res.train) + length(res.test) == 50
+  @test Set(vcat(res.train, res.test)) == Set(1:50)
+end


### PR DESCRIPTION
Peels concentric shells (Onion algorithm) to build diverse train/test splits. XYOnionSplit extends Onion to joint X–y space via normalised SPXY distance, mirroring the same dual-coverage idea as SPXYSplit.