### PR TITLE
Test on Julia 1.9 instead of lts (1.10)

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "lts"
+          - "1.9"
           - "1"
         os:
           - ubuntu-latest

--- a/.github/workflows/TestOnPRs.yml
+++ b/.github/workflows/TestOnPRs.yml
@@ -18,12 +18,18 @@ concurrency:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.9"
+          - "1"
     uses: ./.github/workflows/ReusableTest.yml
     with:
       os: ubuntu-latest
-      version: "1"
+      version: ${{ matrix.version }}
       arch: x64
       allow_failure: false
-      run_codecov: true
+      run_codecov: ${{ matrix.version == '1' }}
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `lts` (currently Julia 1.10) with `1.9` in `Test.yml` matrix
- Add `1.9` to the `TestOnPRs.yml` matrix so PRs are validated against both 1.9 and latest 1.x

The project targets `julia = "1.9"` in `Project.toml`, so CI should validate against that minimum version.